### PR TITLE
changed addCacheTimerHeader switch

### DIFF
--- a/resources/config/laravel-responsecache.php
+++ b/resources/config/laravel-responsecache.php
@@ -27,7 +27,7 @@ return [
      * with the cache time should be added to a cached response. This
      * can be handy when debugging.
      */
-    'addCacheTimeHeader' => true,
+    'addCacheTimeHeader' => env('APP_DEBUG', true),
 
     /*
      * Here you may define the cache store that should be used to store


### PR DESCRIPTION
addCacheTimer option is handy when debugging, so why don’t control it using Laravel’s ‘APP_DEBUG’ key? :)