### PR TITLE
Use .env variable for cacheLifetimeInMinutes configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ return [
      * When using the default CacheRequestFilter this setting controls the
      * number of minutes responses must be cached.
      */
-    'cacheLifetimeInMinutes' => 60 * 24 * 7,
+    'cacheLifetimeInMinutes' => env('RESPONSE_CACHE_LIFETIME', 60 * 24 * 7),
 
     /*
      * This setting determines if a http header named "Laravel-responsecache"

--- a/resources/config/laravel-responsecache.php
+++ b/resources/config/laravel-responsecache.php
@@ -20,7 +20,7 @@ return [
      * When using the default CacheRequestFilter this setting controls the
      * number of minutes responses must be cached.
      */
-    'cacheLifetimeInMinutes' => 60 * 24 * 7,
+    'cacheLifetimeInMinutes' => env('RESPONSE_CACHE_LIFETIME', 60 * 24 * 7),
 
     /*
      * This setting determines if a http header named "Laravel-responsecache"


### PR DESCRIPTION
Added the `RESPONSE_CACHE_LIFETIME` environment variable to allow custom configuration through the .env file