### PR TITLE
Add Lumen support

### DIFF
--- a/src/CacheProfiles/BaseCacheProfile.php
+++ b/src/CacheProfiles/BaseCacheProfile.php
@@ -3,17 +3,17 @@
 namespace Spatie\ResponseCache\CacheProfiles;
 
 use Carbon\Carbon;
-use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Container\Container;
 use Illuminate\Http\Request;
 
 abstract class BaseCacheProfile
 {
     /**
-     * @var \Illuminate\Contracts\Foundation\Application
+     * @var Illuminate\Contracts\Container\Container
      */
     protected $app;
 
-    public function __construct(Application $app)
+    public function __construct(Container $app)
     {
         $this->app = $app;
     }

--- a/src/LumenResponseCacheServiceProvider.php
+++ b/src/LumenResponseCacheServiceProvider.php
@@ -9,26 +9,18 @@ use Spatie\ResponseCache\Commands\ClearCommand;
 use Spatie\ResponseCache\Middlewares\DoNotCacheResponseMiddleware;
 use Spatie\ResponseCache\Middlewares\ResponseCacheMiddleware;
 
-class ResponseCacheServiceProvider extends ServiceProvider
+class LumenResponseCacheServiceProvider extends ServiceProvider
 {
     /**
      * Bootstrap the application services.
      */
     public function boot()
     {
-        $this->publishes([
-            __DIR__.'/../resources/config/laravel-responsecache.php' => config_path('laravel-responsecache.php'),
-        ], 'config');
-
         $this->app->bind(CacheProfile::class, function (Container $app) {
             return $app->make(config('laravel-responsecache.cacheProfile'));
         });
 
         $this->app->singleton('laravel-responsecache', ResponseCache::class);
-
-        $this->app['command.responsecache:clear'] = $this->app->make(ClearCommand::class);
-
-        $this->commands(['command.responsecache:clear']);
     }
 
     /**
@@ -38,7 +30,9 @@ class ResponseCacheServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__.'/../resources/config/laravel-responsecache.php', 'laravel-responsecache');
 
-        $this->app[\Illuminate\Contracts\Http\Kernel::class]->pushMiddleware(ResponseCacheMiddleware::class);
-        $this->app[\Illuminate\Routing\Router::class]->middleware('doNotCacheResponse', DoNotCacheResponseMiddleware::class);
+        $this->app->middleware([ResponseCacheMiddleware::class]);
+        $this->app->routeMiddleware([
+            'doNotCacheResponse' => DoNotCacheResponseMiddleware::class
+        ]);
     }
 }

--- a/src/ResponseCacheRepository.php
+++ b/src/ResponseCacheRepository.php
@@ -3,7 +3,7 @@
 namespace Spatie\ResponseCache;
 
 use Illuminate\Contracts\Config\Repository as Repository;
-use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Contracts\Container\Container;
 
 class ResponseCacheRepository
 {
@@ -23,10 +23,10 @@ class ResponseCacheRepository
     protected $cacheStoreName;
 
     /**
-     * @param \Illuminate\Contracts\Foundation\Application $app
+     * @param \Illuminate\Contracts\Container\Container $app
      * @param \Spatie\ResponseCache\ResponseSerializer     $responseSerializer
      */
-    public function __construct(Application $app, ResponseSerializer $responseSerializer, Repository $config)
+    public function __construct(Container $app, ResponseSerializer $responseSerializer, Repository $config)
     {
         $this->cache = $app['cache']->store($config->get('laravel-responsecache.cacheStore'));
         $this->responseSerializer = $responseSerializer;


### PR DESCRIPTION
* Use the `Container` contract instead of the `Application` one as the latter is not fully implemented in Lumen
* Add a basic `LumenServiceProvider`. I removed the command registration because of a dependency injection error that I did not have time to debug.  

 `IntegrationTest::it_will_not_cache_errors()` was failing for me before this change. It is caused by the `ExceptionHandler` kicking in. I fixed locally based on [this gist](https://gist.github.com/adamwathan/c9752f61102dc056d157) but did not include that fix in this pull request as might be related to my own environment.