### PR TITLE
Added test to show that the session is always empty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 docs
 vendor
 tests/temp
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ composer.lock
 docs
 vendor
 tests/temp
-.idea/

--- a/src/CacheProfiles/CacheAllSuccessfulGetRequestsBasedOnSessionId.php
+++ b/src/CacheProfiles/CacheAllSuccessfulGetRequestsBasedOnSessionId.php
@@ -14,7 +14,11 @@ class CacheAllSuccessfulGetRequestsBasedOnSessionId extends CacheAllSuccessfulGe
      */
     public function cacheNameSuffix(Request $request)
     {
-        return $this->app->session->all();
+        if(empty($this->app->session->all())) {
+            return 'empty';
+        } else {
+            return $this->app->session->getId();
+        }
     }
 
 

--- a/src/CacheProfiles/CacheAllSuccessfulGetRequestsBasedOnSessionId.php
+++ b/src/CacheProfiles/CacheAllSuccessfulGetRequestsBasedOnSessionId.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Spatie\ResponseCache\CacheProfiles;
+
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class CacheAllSuccessfulGetRequestsBasedOnSessionId extends CacheAllSuccessfulGetRequests
+{
+    /**
+     * Set a string to add to differentiate this request from others.
+     *
+     * @return string
+     */
+    public function cacheNameSuffix(Request $request)
+    {
+        return $this->app->session->all();
+    }
+
+
+
+}

--- a/src/CacheProfiles/CacheAllSuccessfulGetRequestsBasedOnSessionId.php
+++ b/src/CacheProfiles/CacheAllSuccessfulGetRequestsBasedOnSessionId.php
@@ -3,7 +3,6 @@
 namespace Spatie\ResponseCache\CacheProfiles;
 
 use Illuminate\Http\Request;
-use Symfony\Component\HttpFoundation\Response;
 
 class CacheAllSuccessfulGetRequestsBasedOnSessionId extends CacheAllSuccessfulGetRequests
 {

--- a/tests/CacheProfiles/CacheAllSuccessfulGetRequestsBasedOnSessionIdTest.php
+++ b/tests/CacheProfiles/CacheAllSuccessfulGetRequestsBasedOnSessionIdTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Spatie\ResponseCache\Test\CacheProfiles;
+
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Spatie\ResponseCache\CacheProfiles\CacheAllSuccessfulGetRequests;
+use Spatie\ResponseCache\CacheProfiles\CacheAllSuccessfulGetRequestsBasedOnSessionId;
+use Spatie\ResponseCache\Test\TestCase;
+use Spatie\ResponseCache\Test\User;
+use Symfony\Component\HttpFoundation\Response;
+
+class CacheAllSuccessfulGetRequestsBasedOnSessionIdTest extends TestCase
+{
+    /**
+     * @var \Spatie\ResponseCache\CacheProfiles\CacheAllSuccessfulGetRequestsBasedOnSessionId
+     */
+    protected $cacheProfile;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->cacheProfile = app(CacheAllSuccessfulGetRequestsBasedOnSessionId::class);
+    }
+
+
+    /**
+     * @test
+     */
+    public function it_will_use_the_session_id_to_differentiate_caches()
+    {
+        $request = new Request();
+        $request->setMethod('get');
+        $this->assertNotEmpty($this->cacheProfile->cacheNameSuffix($request));
+    }
+
+}

--- a/tests/CacheProfiles/CacheAllSuccessfulGetRequestsBasedOnSessionIdTest.php
+++ b/tests/CacheProfiles/CacheAllSuccessfulGetRequestsBasedOnSessionIdTest.php
@@ -2,13 +2,9 @@
 
 namespace Spatie\ResponseCache\Test\CacheProfiles;
 
-use Carbon\Carbon;
 use Illuminate\Http\Request;
-use Spatie\ResponseCache\CacheProfiles\CacheAllSuccessfulGetRequests;
 use Spatie\ResponseCache\CacheProfiles\CacheAllSuccessfulGetRequestsBasedOnSessionId;
 use Spatie\ResponseCache\Test\TestCase;
-use Spatie\ResponseCache\Test\User;
-use Symfony\Component\HttpFoundation\Response;
 
 class CacheAllSuccessfulGetRequestsBasedOnSessionIdTest extends TestCase
 {

--- a/tests/CacheProfiles/CacheAllSuccessfulGetRequestsTest.php
+++ b/tests/CacheProfiles/CacheAllSuccessfulGetRequestsTest.php
@@ -5,6 +5,7 @@ namespace Spatie\ResponseCache\Test\CacheProfiles;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Spatie\ResponseCache\CacheProfiles\CacheAllSuccessfulGetRequests;
+use Spatie\ResponseCache\CacheProfiles\CacheAllSuccessfulGetRequestsBasedOnSessionId;
 use Spatie\ResponseCache\Test\TestCase;
 use Spatie\ResponseCache\Test\User;
 use Symfony\Component\HttpFoundation\Response;


### PR DESCRIPTION
This PR shows that in the cacheNameSuffix() function the Session::all() or $this->app->session->all() is alway empty.

Refer to #27 for reasoning behind this.