### PR TITLE
Option to use cache store tags

### DIFF
--- a/config/responsecache.php
+++ b/config/responsecache.php
@@ -34,4 +34,9 @@ return [
      * configured in app/config/cache.php
      */
     'cache_store' => env('RESPONSE_CACHE_DRIVER', 'file'),
+
+    /*
+     * If selected cache driver supports tagging you can define it here.
+     */
+    'cache_tags' => env('RESPONSE_CACHE_STORE_TAG', null),
 ];

--- a/src/Commands/Flush.php
+++ b/src/Commands/Flush.php
@@ -3,9 +3,9 @@
 namespace Spatie\ResponseCache\Commands;
 
 use Illuminate\Console\Command;
+use Spatie\ResponseCache\ResponseCacheRepository;
 use Spatie\ResponseCache\Events\FlushedResponseCache;
 use Spatie\ResponseCache\Events\FlushingResponseCache;
-use Spatie\ResponseCache\ResponseCacheRepository;
 
 class Flush extends Command
 {

--- a/src/Commands/Flush.php
+++ b/src/Commands/Flush.php
@@ -3,9 +3,9 @@
 namespace Spatie\ResponseCache\Commands;
 
 use Illuminate\Console\Command;
-use Illuminate\Cache\CacheManager;
 use Spatie\ResponseCache\Events\FlushedResponseCache;
 use Spatie\ResponseCache\Events\FlushingResponseCache;
+use Spatie\ResponseCache\ResponseCacheRepository;
 
 class Flush extends Command
 {
@@ -13,13 +13,11 @@ class Flush extends Command
 
     protected $description = 'Flush the response cache';
 
-    public function handle()
+    public function handle(ResponseCacheRepository $cache)
     {
-        $storeName = config('responsecache.cache_store');
-
         event(new FlushingResponseCache());
 
-        app(CacheManager::class)->store($storeName)->flush();
+        $cache->flush();
 
         event(new FlushedResponseCache());
 

--- a/src/ResponseCacheServiceProvider.php
+++ b/src/ResponseCacheServiceProvider.php
@@ -26,7 +26,11 @@ class ResponseCacheServiceProvider extends ServiceProvider
         $this->app->when(ResponseCacheRepository::class)
             ->needs(Repository::class)
             ->give(function (): Repository {
-                return $this->app['cache']->store(config('responsecache.cache_store'));
+                $repository = $this->app['cache']->store(config('responsecache.cache_store'));
+                if (config('responsecache.cache_tags')) {
+                    return $repository->tags(config('repositorycache.cache_tags'));
+                }
+                return $repository;
             });
 
         $this->app->singleton('responsecache', ResponseCache::class);

--- a/src/ResponseCacheServiceProvider.php
+++ b/src/ResponseCacheServiceProvider.php
@@ -30,7 +30,7 @@ class ResponseCacheServiceProvider extends ServiceProvider
                 if (config('responsecache.cache_tags')) {
                     return $repository->tags(config('repositorycache.cache_tags'));
                 }
-                
+
                 return $repository;
             });
 

--- a/src/ResponseCacheServiceProvider.php
+++ b/src/ResponseCacheServiceProvider.php
@@ -30,6 +30,7 @@ class ResponseCacheServiceProvider extends ServiceProvider
                 if (config('responsecache.cache_tags')) {
                     return $repository->tags(config('repositorycache.cache_tags'));
                 }
+                
                 return $repository;
             });
 

--- a/tests/Commands/FlushCommandTest.php
+++ b/tests/Commands/FlushCommandTest.php
@@ -3,10 +3,12 @@
 namespace Spatie\ResponseCache\Test\Commands;
 
 use Event;
+use Illuminate\Cache\Repository;
 use Illuminate\Support\Facades\Artisan;
 use Spatie\ResponseCache\Test\TestCase;
 use Spatie\ResponseCache\Events\FlushedResponseCache;
 use Spatie\ResponseCache\Events\FlushingResponseCache;
+use Spatie\ResponseCache\ResponseCacheRepository;
 
 class FlushCommandTest extends TestCase
 {
@@ -34,5 +36,39 @@ class FlushCommandTest extends TestCase
 
         Event::assertDispatched(FlushingResponseCache::class);
         Event::assertDispatched(FlushedResponseCache::class);
+    }
+
+    /** @test */
+    public function it_will_preserve_cache_when_tags_are_on()
+    {
+        $responseCache = $this->createTaggableResponseCacheStore(['responsecache', 'otherTag']);
+        $appCache = $this->app['cache']->store('array');
+
+        $appCache->forever('appData', 'someValue');
+        $responseCache->flush();
+
+        $this->assertEquals('someValue', $appCache->get('appData'));
+    }
+
+    /** @test */
+    public function it_will_flush_all_when_tags_are_not_defined()
+    {
+        $responseCache = $this->createTaggableResponseCacheStore(null);
+        $appCache = $this->app['cache']->store('array');
+
+        $appCache->forever('appData', 'someValue');
+        $responseCache->flush();
+
+        $this->assertNull($appCache->get('appData'));
+    }
+
+    protected function createTaggableResponseCacheStore($tags)
+    {
+        $this->app['config']->set('responsecache.cache_store', 'array');
+        $this->app['config']->set('responsecache.cache_tags', $tags);
+
+        // Simulating construction of Repository inside of the service provider
+        return $this->app->contextual[ResponseCacheRepository::class][$this->app->getAlias(Repository::class)]();
+
     }
 }

--- a/tests/Commands/FlushCommandTest.php
+++ b/tests/Commands/FlushCommandTest.php
@@ -6,9 +6,9 @@ use Event;
 use Illuminate\Cache\Repository;
 use Illuminate\Support\Facades\Artisan;
 use Spatie\ResponseCache\Test\TestCase;
+use Spatie\ResponseCache\ResponseCacheRepository;
 use Spatie\ResponseCache\Events\FlushedResponseCache;
 use Spatie\ResponseCache\Events\FlushingResponseCache;
-use Spatie\ResponseCache\ResponseCacheRepository;
 
 class FlushCommandTest extends TestCase
 {
@@ -69,6 +69,5 @@ class FlushCommandTest extends TestCase
 
         // Simulating construction of Repository inside of the service provider
         return $this->app->contextual[ResponseCacheRepository::class][$this->app->getAlias(Repository::class)]();
-
     }
 }


### PR DESCRIPTION
If `store_tags` option is present, response cache will try to use tags. Of course driver must support tags and by default it is null.

To avoid configuring used cache twice (setting store, and selected tags) I injected ResponseCacheRepository using method injection of the Flush command.