### PR TITLE
add special handling for file responses, fixes #66

### DIFF
--- a/src/ResponseSerializer.php
+++ b/src/ResponseSerializer.php
@@ -40,6 +40,7 @@ class ResponseSerializer
         }
 
         $content = $response->getContent();
+
         return compact('content', 'statusCode', 'headers', 'type');
     }
 

--- a/src/ResponseSerializer.php
+++ b/src/ResponseSerializer.php
@@ -2,24 +2,42 @@
 
 namespace Spatie\ResponseCache;
 
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Response;
 
 class ResponseSerializer
 {
+    const RESPONSE_TYPE_NORMAL = 1;
+    const RESPONSE_TYPE_FILE = 2;
+
     public function serialize(Response $response): string
     {
-        $content = $response->getContent();
+        $type = self::RESPONSE_TYPE_NORMAL;
+
+        if ($response instanceof BinaryFileResponse) {
+            $content = $response->getFile()->getPathname();
+            $type = self::RESPONSE_TYPE_FILE;
+        } else {
+            $content = $response->getContent();
+        }
+
         $statusCode = $response->getStatusCode();
         $headers = $response->headers;
 
-        return serialize(compact('content', 'statusCode', 'headers'));
+        return serialize(compact('content', 'statusCode', 'headers', 'type'));
     }
 
     public function unserialize(string $serializedResponse): Response
     {
         $responseProperties = unserialize($serializedResponse);
 
-        $response = new Response($responseProperties['content'], $responseProperties['statusCode']);
+        $type = $responseProperties['type'] ?? self::RESPONSE_TYPE_NORMAL;
+
+        if ($type === self::RESPONSE_TYPE_FILE) {
+            $response = new BinaryFileResponse($responseProperties['content'], $responseProperties['statusCode']);
+        } else {
+            $response = new Response($responseProperties['content'], $responseProperties['statusCode']);
+        }
 
         $response->headers = $responseProperties['headers'];
 

--- a/src/ResponseSerializer.php
+++ b/src/ResponseSerializer.php
@@ -28,7 +28,7 @@ class ResponseSerializer
 
     private function getResponseData(Response $response): array
     {
-        $type= self::RESPONSE_TYPE_NORMAL;
+        $type = self::RESPONSE_TYPE_NORMAL;
         $statusCode = $response->getStatusCode();
         $headers = $response->headers;
 
@@ -43,7 +43,8 @@ class ResponseSerializer
         return compact('content', 'statusCode', 'headers', 'type');
     }
 
-    private function buildResponse(array $responseProperties): Response{
+    private function buildResponse(array $responseProperties): Response
+    {
         $type = $responseProperties['type'] ?? self::RESPONSE_TYPE_NORMAL;
 
         if ($type === self::RESPONSE_TYPE_FILE) {

--- a/src/ResponseSerializer.php
+++ b/src/ResponseSerializer.php
@@ -2,8 +2,8 @@
 
 namespace Spatie\ResponseCache;
 
-use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class ResponseSerializer
 {

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -168,4 +168,16 @@ class IntegrationTest extends TestCase
 
         $this->assertDifferentResponse($firstResponse, $secondResponse);
     }
+
+    /** @test */
+    public function it_will_cache_file_responses()
+    {
+        $firstResponse = $this->call('get', '/image');
+        $secondResponse = $this->call('get', '/image');
+
+        $this->assertRegularResponse($firstResponse);
+        $this->assertCachedResponse($secondResponse);
+
+        $this->assertSameResponse($firstResponse, $secondResponse);
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -123,6 +123,10 @@ abstract class TestCase extends Orchestra
         Route::any('/uncacheable', ['middleware' => 'doNotCacheResponse', function () {
             return 'uncacheable '.str_random();
         }]);
+
+        Route::any('/image', function() {
+            return response()->file(__DIR__ . '/User.php');
+        });
     }
 
     public function getTempDirectory($suffix = '')

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -124,8 +124,8 @@ abstract class TestCase extends Orchestra
             return 'uncacheable '.str_random();
         }]);
 
-        Route::any('/image', function() {
-            return response()->file(__DIR__ . '/User.php');
+        Route::any('/image', function () {
+            return response()->file(__DIR__.'/User.php');
         });
     }
 


### PR DESCRIPTION
Add a check if the response to serialize is an instance of `BinaryFileResponse`. If true the type will be set accordingly.

On unserialize the response object will be created based on the given type. Default value for `$type` is set to `RESPONSE_TYPE_NORMAL`.