### PR TITLE
Updated to Mockery 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "require-dev": {
         "phpunit/phpunit" : "^6.2",
         "orchestra/testbench": "~3.5.0",
-        "mockery/mockery": "^0.9.9"
+        "mockery/mockery": "^1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Updated `mockery/mockery` to [`^1.0`](https://github.com/mockery/mockery/releases/tag/1.0).