### PR TITLE
Improve unserializable response handling

### DIFF
--- a/src/Exceptions/CouldNotUnserialize.php
+++ b/src/Exceptions/CouldNotUnserialize.php
@@ -4,10 +4,10 @@ namespace Spatie\ResponseCache\Exceptions;
 
 use Exception;
 
-class CouldntUnserialize extends Exception
+class CouldNotUnserialize extends Exception
 {
     public static function serializedResponse(string $serializedResponse): self
     {
-        return new static("Couldn't unserialize `{$serializedResponse}`");
+        return new static("Could not unserialize `{$serializedResponse}`");
     }
 }

--- a/src/Exceptions/CouldntUnserialize.php
+++ b/src/Exceptions/CouldntUnserialize.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\ResponseCache\Exceptions;
+
+use Exception;
+
+class CouldntUnserialize extends Exception
+{
+    public static function serializedResponse(string $serializedResponse): self
+    {
+        return new static("Couldn't unserialize `{$serializedResponse}`");
+    }
+}

--- a/src/ResponseSerializer.php
+++ b/src/ResponseSerializer.php
@@ -2,7 +2,7 @@
 
 namespace Spatie\ResponseCache;
 
-use Spatie\ResponseCache\Exceptions\CouldntUnserialize;
+use Spatie\ResponseCache\Exceptions\CouldNotUnserialize;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -21,7 +21,7 @@ class ResponseSerializer
         $responseProperties = unserialize($serializedResponse);
 
         if (! $this->containsValidResponseProperties($responseProperties)) {
-            throw CouldntUnserialize::serializedResponse($serializedResponse);
+            throw CouldNotUnserialize::serializedResponse($serializedResponse);
         }
 
         $response = $this->buildResponse($responseProperties);

--- a/src/ResponseSerializer.php
+++ b/src/ResponseSerializer.php
@@ -2,8 +2,9 @@
 
 namespace Spatie\ResponseCache;
 
-use Symfony\Component\HttpFoundation\Response;
+use Spatie\ResponseCache\Exceptions\CouldntUnserialize;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 class ResponseSerializer
 {
@@ -18,6 +19,10 @@ class ResponseSerializer
     public function unserialize(string $serializedResponse): Response
     {
         $responseProperties = unserialize($serializedResponse);
+
+        if (! $this->containsValidResponseProperties($responseProperties)) {
+            throw CouldntUnserialize::serializedResponse($serializedResponse);
+        }
 
         $response = $this->buildResponse($responseProperties);
 
@@ -42,6 +47,19 @@ class ResponseSerializer
         $type = self::RESPONSE_TYPE_NORMAL;
 
         return compact('statusCode', 'headers', 'content', 'type');
+    }
+
+    protected function containsValidResponseProperties($properties): bool
+    {
+        if (! is_array($properties)) {
+            return false;
+        }
+
+        if (! isset($properties['content'], $properties['statusCode'])) {
+            return false;
+        }
+
+        return true;
     }
 
     protected function buildResponse(array $responseProperties): Response

--- a/tests/ResponseSerializerTest.php
+++ b/tests/ResponseSerializerTest.php
@@ -4,7 +4,7 @@ namespace Spatie\ResponseCache\Test;
 
 use Spatie\ResponseCache\ResponseSerializer;
 use Symfony\Component\HttpFoundation\Response;
-use Spatie\ResponseCache\Exceptions\CouldntUnserialize;
+use Spatie\ResponseCache\Exceptions\CouldNotUnserialize;
 
 class ResponseSerializerTest extends TestCase
 {
@@ -51,7 +51,7 @@ class ResponseSerializerTest extends TestCase
     /** @test */
     public function it_throws_when_something_something_else_than_a_response_is_unserialized()
     {
-        $this->expectException(CouldntUnserialize::class);
+        $this->expectException(CouldNotUnserialize::class);
 
         $this->responseSerializer->unserialize('b:0;');
     }

--- a/tests/ResponseSerializerTest.php
+++ b/tests/ResponseSerializerTest.php
@@ -49,7 +49,7 @@ class ResponseSerializerTest extends TestCase
     }
 
     /** @test */
-    public function it_throws_when_something_something_else_than_a_response_is_unserialized()
+    public function it_throws_an_exception_when_something_else_than_a_response_is_unserialized()
     {
         $this->expectException(CouldNotUnserialize::class);
 

--- a/tests/ResponseSerializerTest.php
+++ b/tests/ResponseSerializerTest.php
@@ -4,6 +4,7 @@ namespace Spatie\ResponseCache\Test;
 
 use Spatie\ResponseCache\ResponseSerializer;
 use Symfony\Component\HttpFoundation\Response;
+use Spatie\ResponseCache\Exceptions\CouldntUnserialize;
 
 class ResponseSerializerTest extends TestCase
 {
@@ -45,5 +46,13 @@ class ResponseSerializerTest extends TestCase
         $this->assertEquals($this->statusCode, $unserializedResponse->getStatusCode());
 
         $this->assertEquals('testValue', $unserializedResponse->headers->get('testHeader'));
+    }
+
+    /** @test */
+    public function it_throws_when_something_something_else_than_a_response_is_unserialized()
+    {
+        $this->expectException(CouldntUnserialize::class);
+
+        $this->responseSerializer->unserialize('b:0;');
     }
 }


### PR DESCRIPTION
Kind of fixes #102 

I'd rather treat a case like this as an uncached response, but since `ResponseCache::getCachedResponseFor` has `Response` as a strict return type, we can't modify the behaviour without a breaking change.

I propose we provide a clear exception until we work on the next major version.