### PR TITLE
 Change command to clear instead of flush

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ return [
     /*
      * If the cache driver you configured supports tags, you may specify a tag name
      * here. All responses will be tagged. When clearing the responsecache only
-     * items with that tag will be flushed.
+     * items with that tag will be cleared.
      *
      * You may use a string or an array here.
      */
@@ -114,17 +114,17 @@ By default the package will cache all successful `get`-requests for a week.
 Logged in users will each have their own separate cache. If this behaviour is what you
  need, you're done: installing the `ResponseCacheServerProvider` was enough.
 
-### Flushing the cache
-The entire cache can be flushed with:
+### Clearing the cache
+The entire cache can be cleared with:
 ```php
-ResponseCache::flush();
+ResponseCache::clear();
 ```
-This will flush everything from the cache store specified in the config-file.
+This will clear everything from the cache store specified in the config-file.
 
 The same can be accomplished by issuing this artisan command:
 
 ```bash
-$ php artisan responsecache:flush
+$ php artisan responsecache:clear
 ```
 
 ### Preventing a request from being cached
@@ -237,13 +237,13 @@ This event is fired when a request passes through the `ResponseCache` middleware
 
 This event is fired when a request passes through the `ResponseCache` middleware but no cached response was found or returned.
 
-#### FlushingResponseCache and FlushedResponseCache
+#### ClearingResponseCache and ClearedResponseCache
 
-`Spatie\ResponseCache\Events\FlushingResponseCache`
+`Spatie\ResponseCache\Events\ClearingResponseCache`
 
-`Spatie\ResponseCache\Events\FlushedResponseCache`
+`Spatie\ResponseCache\Events\ClearedResponseCache`
 
-These events are fired respectively when the `responsecache:flush` is started and finished.
+These events are fired respectively when the `responsecache:clear` is started and finished.
 
 ### CSRF Tokens
 

--- a/src/Commands/Clear.php
+++ b/src/Commands/Clear.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Spatie\ResponseCache\Commands;
+
+use Illuminate\Console\Command;
+use Spatie\ResponseCache\ResponseCacheRepository;
+use Spatie\ResponseCache\Events\ClearedResponseCache;
+use Spatie\ResponseCache\Events\FlushedResponseCache;
+use Spatie\ResponseCache\Events\ClearingResponseCache;
+use Spatie\ResponseCache\Events\FlushingResponseCache;
+
+class Clear extends Command
+{
+    protected $signature = 'responsecache:clear';
+
+    protected $description = 'Clear the response cache';
+
+    public function handle(ResponseCacheRepository $cache)
+    {
+        event(new FlushingResponseCache());
+        event(new ClearingResponseCache());
+
+        $cache->clear();
+
+        event(new FlushedResponseCache());
+        event(new ClearedResponseCache());
+
+        $this->info('Response cache cleared!');
+    }
+}

--- a/src/Commands/Flush.php
+++ b/src/Commands/Flush.php
@@ -3,24 +3,15 @@
 namespace Spatie\ResponseCache\Commands;
 
 use Illuminate\Console\Command;
-use Spatie\ResponseCache\ResponseCacheRepository;
-use Spatie\ResponseCache\Events\FlushedResponseCache;
-use Spatie\ResponseCache\Events\FlushingResponseCache;
 
 class Flush extends Command
 {
     protected $signature = 'responsecache:flush';
 
-    protected $description = 'Flush the response cache';
+    protected $description = 'Flush the response cache (deprecated - use the clear method)';
 
-    public function handle(ResponseCacheRepository $cache)
+    public function handle()
     {
-        event(new FlushingResponseCache());
-
-        $cache->flush();
-
-        event(new FlushedResponseCache());
-
-        $this->info('Response cache flushed!');
+        $this->call('responsecache:clear');
     }
 }

--- a/src/Events/ClearedResponseCache.php
+++ b/src/Events/ClearedResponseCache.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Spatie\ResponseCache\Events;
+
+class ClearedResponseCache
+{
+}

--- a/src/Events/ClearingResponseCache.php
+++ b/src/Events/ClearingResponseCache.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Spatie\ResponseCache\Events;
+
+class ClearingResponseCache
+{
+}

--- a/src/ResponseCache.php
+++ b/src/ResponseCache.php
@@ -69,9 +69,17 @@ class ResponseCache
         return $this->cache->get($this->hasher->getHashFor($request));
     }
 
+    /**
+     * @deprecated Use the new clear method, this is just an alias.
+     */
     public function flush()
     {
-        $this->cache->flush();
+        $this->clear();
+    }
+
+    public function clear()
+    {
+        $this->cache->clear();
     }
 
     protected function addCachedHeader(Response $response): Response

--- a/src/ResponseCacheRepository.php
+++ b/src/ResponseCacheRepository.php
@@ -39,8 +39,16 @@ class ResponseCacheRepository
         return $this->responseSerializer->unserialize($this->cache->get($key));
     }
 
+    /**
+     * @deprecated Use the new clear method, this is just an alias.
+     */
     public function flush()
     {
-        $this->cache->flush();
+        $this->clear();
+    }
+
+    public function clear()
+    {
+        $this->cache->clear();
     }
 }

--- a/src/ResponseCacheServiceProvider.php
+++ b/src/ResponseCacheServiceProvider.php
@@ -5,6 +5,7 @@ namespace Spatie\ResponseCache;
 use Illuminate\Cache\Repository;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider;
+use Spatie\ResponseCache\Commands\Clear;
 use Spatie\ResponseCache\Commands\Flush;
 use Spatie\ResponseCache\CacheProfiles\CacheProfile;
 
@@ -41,6 +42,7 @@ class ResponseCacheServiceProvider extends ServiceProvider
         if ($this->app->runningInConsole()) {
             $this->commands([
                 Flush::class,
+                Clear::class,
             ]);
         }
     }

--- a/tests/Commands/ClearCommandTest.php
+++ b/tests/Commands/ClearCommandTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Spatie\ResponseCache\Test\Commands;
+
+use Event;
+use Illuminate\Cache\Repository;
+use Illuminate\Support\Facades\Artisan;
+use Spatie\ResponseCache\Test\TestCase;
+use Spatie\ResponseCache\ResponseCacheRepository;
+use Spatie\ResponseCache\Events\ClearedResponseCache;
+use Spatie\ResponseCache\Events\FlushedResponseCache;
+use Spatie\ResponseCache\Events\ClearingResponseCache;
+use Spatie\ResponseCache\Events\FlushingResponseCache;
+
+class ClearCommandTest extends TestCase
+{
+    /** @test */
+    public function it_will_clear_the_cache()
+    {
+        $firstResponse = $this->call('GET', '/random');
+
+        Artisan::call('responsecache:clear');
+
+        $secondResponse = $this->call('GET', '/random');
+
+        $this->assertRegularResponse($firstResponse);
+        $this->assertRegularResponse($secondResponse);
+
+        $this->assertDifferentResponse($firstResponse, $secondResponse);
+    }
+
+    /** @test */
+    public function it_will_fire_events_when_clearing_the_cache()
+    {
+        Event::fake();
+
+        Artisan::call('responsecache:clear');
+
+        Event::assertDispatched(FlushingResponseCache::class);
+        Event::assertDispatched(ClearingResponseCache::class);
+        Event::assertDispatched(FlushedResponseCache::class);
+        Event::assertDispatched(ClearedResponseCache::class);
+    }
+
+    /** @test */
+    public function it_will_clear_all_when_tags_are_not_defined()
+    {
+        $responseCache = $this->createTaggableResponseCacheStore(null);
+        $appCache = $this->app['cache']->store('array');
+
+        $appCache->forever('appData', 'someValue');
+        $responseCache->clear();
+
+        $this->assertNull($appCache->get('appData'));
+    }
+
+    protected function createTaggableResponseCacheStore($tag): Repository
+    {
+        $this->app['config']->set('responsecache.cache_store', 'array');
+        $this->app['config']->set('responsecache.cache_tag', $tag);
+
+        // Simulating construction of Repository inside of the service provider
+        return $this->app->contextual[ResponseCacheRepository::class][$this->app->getAlias(Repository::class)]();
+    }
+}

--- a/tests/Commands/FlushCommandTest.php
+++ b/tests/Commands/FlushCommandTest.php
@@ -2,72 +2,18 @@
 
 namespace Spatie\ResponseCache\Test\Commands;
 
-use Event;
-use Illuminate\Cache\Repository;
 use Illuminate\Support\Facades\Artisan;
 use Spatie\ResponseCache\Test\TestCase;
-use Spatie\ResponseCache\ResponseCacheRepository;
-use Spatie\ResponseCache\Events\FlushedResponseCache;
-use Spatie\ResponseCache\Events\FlushingResponseCache;
 
 class FlushCommandTest extends TestCase
 {
     /** @test */
-    public function it_will_clear_the_cache()
+    public function it_points_to_the_updated_command()
     {
-        $firstResponse = $this->call('GET', '/random');
+        $clearCommand = \Mockery::mock("\Spatie\ResponseCache\Commands\Clear[handle]");
+        $clearCommand->shouldReceive('handle')->once();
+        $this->app['Illuminate\Contracts\Console\Kernel']->registerCommand($clearCommand);
 
         Artisan::call('responsecache:flush');
-
-        $secondResponse = $this->call('GET', '/random');
-
-        $this->assertRegularResponse($firstResponse);
-        $this->assertRegularResponse($secondResponse);
-
-        $this->assertDifferentResponse($firstResponse, $secondResponse);
-    }
-
-    /** @test */
-    public function it_will_fire_events_when_clearing_the_cache()
-    {
-        Event::fake();
-
-        Artisan::call('responsecache:flush');
-
-        Event::assertDispatched(FlushingResponseCache::class);
-        Event::assertDispatched(FlushedResponseCache::class);
-    }
-
-    /** @test */
-    public function it_will_preserve_cache_when_tags_are_on()
-    {
-        $responseCache = $this->createTaggableResponseCacheStore('myTag');
-        $appCache = $this->app['cache']->store('array');
-
-        $appCache->forever('appData', 'someValue');
-        $responseCache->flush();
-
-        $this->assertEquals('someValue', $appCache->get('appData'));
-    }
-
-    /** @test */
-    public function it_will_flush_all_when_tags_are_not_defined()
-    {
-        $responseCache = $this->createTaggableResponseCacheStore(null);
-        $appCache = $this->app['cache']->store('array');
-
-        $appCache->forever('appData', 'someValue');
-        $responseCache->flush();
-
-        $this->assertNull($appCache->get('appData'));
-    }
-
-    protected function createTaggableResponseCacheStore($tag): Repository
-    {
-        $this->app['config']->set('responsecache.cache_store', 'array');
-        $this->app['config']->set('responsecache.cache_tag', $tag);
-
-        // Simulating construction of Repository inside of the service provider
-        return $this->app->contextual[ResponseCacheRepository::class][$this->app->getAlias(Repository::class)]();
     }
 }


### PR DESCRIPTION
This PR changes the package to use clear instead of flush. All tests are passing, no breaking changes introduced.

The flush command now aliases to the clear command and a test was made to check this is working. The old command test was moved to ClearCommandTest and tweaked a bit.

This fixes #85.