### PR TITLE
It can forget a specific cached request

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,13 @@ The same can be accomplished by issuing this artisan command:
 $ php artisan responsecache:clear
 ```
 
+### Forget a specific URI
+
+You can forget a specific URI with:
+```php
+ResponseCache::forget('/some-uri');
+```
+
 ### Preventing a request from being cached
 Requests can be ignored by using the `doNotCacheResponse`-middleware. 
 This middleware [can be assigned to routes and controllers]

--- a/README.md
+++ b/README.md
@@ -127,11 +127,18 @@ The same can be accomplished by issuing this artisan command:
 $ php artisan responsecache:clear
 ```
 
-### Forget a specific URI
+### Forget one or several specific URI(s)
 
-You can forget a specific URI with:
+You can forget specific URIs with:
 ```php
+// Forget one URI
 ResponseCache::forget('/some-uri');
+
+// Forget several URIs
+ResponseCache::forget(['/some-uri', '/other-uri']);
+
+// Alternatively
+ResponseCache::forget('/some-uri', '/other-uri');
 ```
 
 ### Preventing a request from being cached

--- a/src/ResponseCache.php
+++ b/src/ResponseCache.php
@@ -97,15 +97,15 @@ class ResponseCache
     public function forget($uris): self
     {
         $uris = is_array($uris) ? $uris : func_get_args();
-        
-        foreach ($uris as $uri) {
+
+        collect($uris)->each(function ($uri) {
             $request = Request::create($uri);
             $hash = $this->hasher->getHashFor($request);
-    
+
             if ($this->cache->has($hash)) {
                 $this->cache->forget($hash);
             }
-        }
+        });
 
         return $this;
     }

--- a/src/ResponseCache.php
+++ b/src/ResponseCache.php
@@ -91,13 +91,22 @@ class ResponseCache
         return $clonedResponse;
     }
 
-    public function forget(string $uri)
+    /**
+     * @param string|array $uris
+     */
+    public function forget($uris): self
     {
-        $request = Request::create($uri);
-        $hash = $this->hasher->getHashFor($request);
-
-        if ($this->cache->has($hash)) {
-            $this->cache->forget($hash);
+        $uris = is_array($uris) ? $uris : func_get_args();
+        
+        foreach ($uris as $uri) {
+            $request = Request::create($uri);
+            $hash = $this->hasher->getHashFor($request);
+    
+            if ($this->cache->has($hash)) {
+                $this->cache->forget($hash);
+            }
         }
+
+        return $this;
     }
 }

--- a/src/ResponseCache.php
+++ b/src/ResponseCache.php
@@ -90,4 +90,14 @@ class ResponseCache
 
         return $clonedResponse;
     }
+
+    public function forget(string $uri)
+    {
+        $request = Request::create($uri);
+        $hash = $this->hasher->getHashFor($request);
+
+        if ($this->cache->has($hash)) {
+            $this->cache->forget($hash);
+        }
+    }
 }

--- a/src/ResponseCacheRepository.php
+++ b/src/ResponseCacheRepository.php
@@ -51,4 +51,9 @@ class ResponseCacheRepository
     {
         $this->cache->clear();
     }
+
+    public function forget(string $key): bool
+    {
+        return $this->cache->forget($key);
+    }
 }

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -111,6 +111,27 @@ class IntegrationTest extends TestCase
     }
 
     /** @test */
+    public function it_can_forget_several_specific_cached_requests_at_once()
+    {
+        $firstResponseFirstCall = $this->call('GET', '/random/1');
+        $this->assertRegularResponse($firstResponseFirstCall);
+
+        $secondResponseFirstCall = $this->call('GET', '/random/2');
+        $this->assertRegularResponse($secondResponseFirstCall);
+
+        ResponseCache::forget(['/random/1', '/random/2']);
+
+        $firstResponseSecondCall = $this->call('GET', '/random/1');
+        $this->assertRegularResponse($firstResponseSecondCall);
+
+        $secondResponseSecondCall = $this->call('GET', '/random/2');
+        $this->assertRegularResponse($secondResponseSecondCall);
+
+        $this->assertDifferentResponse($firstResponseFirstCall, $firstResponseSecondCall);
+        $this->assertDifferentResponse($secondResponseFirstCall, $secondResponseSecondCall);
+    }
+
+    /** @test */
     public function it_will_cache_responses_for_each_logged_in_user_separately()
     {
         $this->call('GET', '/login/1');

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -97,6 +97,20 @@ class IntegrationTest extends TestCase
     }
 
     /** @test */
+    public function it_can_forget_a_specific_cached_request()
+    {
+        $firstResponse = $this->call('GET', '/random');
+        $this->assertRegularResponse($firstResponse);
+
+        ResponseCache::forget('/random');
+
+        $secondResponse = $this->call('GET', '/random');
+        $this->assertRegularResponse($secondResponse);
+
+        $this->assertDifferentResponse($firstResponse, $secondResponse);
+    }
+
+    /** @test */
     public function it_will_cache_responses_for_each_logged_in_user_separately()
     {
         $this->call('GET', '/login/1');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -111,7 +111,7 @@ abstract class TestCase extends Orchestra
             return redirect('/');
         });
 
-        Route::any('/random', function () {
+        Route::any('/random/{id?}', function () {
             return str_random();
         });
 


### PR DESCRIPTION
This PR allows to forget a specific cached request as discussed in https://github.com/spatie/laravel-responsecache/issues/72 and https://github.com/spatie/laravel-responsecache/issues/3