### PR TITLE
Minimum support for Lumen

### DIFF
--- a/src/CacheProfiles/BaseCacheProfile.php
+++ b/src/CacheProfiles/BaseCacheProfile.php
@@ -28,8 +28,8 @@ abstract class BaseCacheProfile implements CacheProfile
      */
     public function cacheNameSuffix(Request $request): string
     {
-        if (auth()->check()) {
-            return auth()->user()->id;
+        if (\Auth::check()) {
+            return \Auth::user()->id;
         }
 
         return '';

--- a/src/ResponseCacheServiceProvider.php
+++ b/src/ResponseCacheServiceProvider.php
@@ -3,7 +3,7 @@
 namespace Spatie\ResponseCache;
 
 use Illuminate\Cache\Repository;
-use Illuminate\Foundation\Application;
+use Illuminate\Container\Container;
 use Illuminate\Support\ServiceProvider;
 use Spatie\ResponseCache\Commands\Clear;
 use Spatie\ResponseCache\Commands\Flush;
@@ -20,7 +20,7 @@ class ResponseCacheServiceProvider extends ServiceProvider
             __DIR__.'/../config/responsecache.php' => config_path('responsecache.php'),
         ], 'config');
 
-        $this->app->bind(CacheProfile::class, function (Application $app) {
+        $this->app->bind(CacheProfile::class, function (Container $app) {
             return $app->make(config('responsecache.cache_profile'));
         });
 


### PR DESCRIPTION
Only with this little changes you have support for Lumen :)

- Allow support for both Laravel and Lumen (Illuminate\Foundation\Application and Laravel\Lumen\Application) with the Illuminate\Container\Container extends
- Usage of '\Auth::' intead of 'auth()->'