### PR TITLE
Hasher uses request-path instead of request-uri

### DIFF
--- a/src/RequestHasher.php
+++ b/src/RequestHasher.php
@@ -18,7 +18,7 @@ class RequestHasher
     public function getHashFor(Request $request): string
     {
         return 'responsecache-'.md5(
-            "{$request->getUri()}/{$request->getMethod()}/".$this->cacheProfile->cacheNameSuffix($request)
+            "{$request->getPathInfo()}/{$request->getMethod()}/".$this->cacheProfile->cacheNameSuffix($request)
         );
     }
 }

--- a/tests/ResponseHasherTest.php
+++ b/tests/ResponseHasherTest.php
@@ -36,7 +36,7 @@ class ResponseHasherTest extends TestCase
     {
         $this->cacheProfile->shouldReceive('cacheNameSuffix')->andReturn('cacheProfileSuffix');
 
-        $this->assertEquals('responsecache-cc8efc2f40ad10ba3cf932adc786aeb5',
+        $this->assertEquals('responsecache-1906a94776759c109dba2177825ade33',
             $this->requestHasher->getHashFor($this->request));
     }
 }


### PR DESCRIPTION
This will prevent the hasher returning different results because the HTTP_HOST is different.