### PR TITLE
Refresh csrf token on cached responses

### DIFF
--- a/src/Middlewares/CacheResponse.php
+++ b/src/Middlewares/CacheResponse.php
@@ -25,7 +25,25 @@ class CacheResponse
             if ($this->responseCache->hasBeenCached($request)) {
                 event(new ResponseCacheHit($request));
 
-                return $this->responseCache->getCachedResponseFor($request);
+                $response = $this->responseCache->getCachedResponseFor($request);
+
+                $pattern = '/<meta name="csrf-token" content="([^"]+)">/';
+
+                $cachedContent = $response->getContent();
+
+                if (preg_match($pattern, $cachedContent, $matches)) {
+
+                    $cachedCsrf = $matches[1];
+                    $updatedCsrf = csrf_token();
+
+                    $updatedContent = str_replace($cachedCsrf, $updatedCsrf, $cachedContent);
+
+                    $response->setContent($updatedContent);
+
+                }
+
+                return $response;
+
             }
         }
 

--- a/src/Middlewares/CacheResponse.php
+++ b/src/Middlewares/CacheResponse.php
@@ -32,18 +32,15 @@ class CacheResponse
                 $cachedContent = $response->getContent();
 
                 if (preg_match($pattern, $cachedContent, $matches)) {
-
                     $cachedCsrf = $matches[1];
                     $updatedCsrf = csrf_token();
 
                     $updatedContent = str_replace($cachedCsrf, $updatedCsrf, $cachedContent);
 
                     $response->setContent($updatedContent);
-
                 }
 
                 return $response;
-
             }
         }
 

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -264,5 +264,4 @@ class IntegrationTest extends TestCase
 
         $this->assertSameResponse($firstResponse, $secondResponse);
     }
-
 }

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -252,4 +252,17 @@ class IntegrationTest extends TestCase
         $thirdResponse = $this->call('get', '/cache-for-given-lifetime');
         $this->assertRegularResponse($thirdResponse);
     }
+
+    /** @test */
+    public function it_will_refresh_token_on_cached_response()
+    {
+        $firstResponse = $this->call('get', '/csrf');
+        $secondResponse = $this->call('get', '/csrf');
+
+        $this->assertRegularResponse($firstResponse);
+        $this->assertCachedResponse($secondResponse);
+
+        $this->assertSameResponse($firstResponse, $secondResponse);
+    }
+
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -115,6 +115,14 @@ abstract class TestCase extends Orchestra
             return str_random();
         });
 
+
+        Route::group(['middleware' => ['web']], function () {
+            Route::any('/csrf/{id?}', function () {
+                return '<meta name="csrf-token" content="' . csrf_token() . '">';
+            });
+        });
+
+
         Route::any('/redirect', function () {
             return redirect('/');
         });

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -115,13 +115,11 @@ abstract class TestCase extends Orchestra
             return str_random();
         });
 
-
         Route::group(['middleware' => ['web']], function () {
             Route::any('/csrf/{id?}', function () {
-                return '<meta name="csrf-token" content="' . csrf_token() . '">';
+                return '<meta name="csrf-token" content="'.csrf_token().'">';
             });
         });
-
 
         Route::any('/redirect', function () {
             return redirect('/');


### PR DESCRIPTION
Hi spatie,

as I am regularly using your open source efforts and want to contribute to open source, too, I may have figured out a way to refresh csrf tokens on cached responses. Inspired by the blogpost [https://christoph-rumpel.com/2018/03/laravel-response-caching-and-csp](url) by @christophrumpel, I found a way to update the token.

One requirement though: It works only on the blade views, as the token has to be set as a meta tag within the html header like this:

```<meta name="csrf-token" content="{{ csrf_token() }}">```

This allows the CacheResponse-Middleware to get the cached csrf_token with Regex and replace all of its appearances in the cached html with a fresh one. But maybe there is a better and more robust solution to that.

I've added a simple test to verify that feature.

Hopefully this is fine like that, but if I did not meet your standards, please let me know, so I can maybe improve it or at least may know, what I could have done better.

Cheers,

Chris