### PR TITLE
It makes possible to delete all prefix based cached items.

### DIFF
--- a/config/responsecache.php
+++ b/config/responsecache.php
@@ -42,5 +42,5 @@ return [
      *
      * You may use a string or an array here.
      */
-    'cache_tag' => '',
+    'cache_tag' => env('RESPONSE_CACHE_TAG', 'responsecache'),
 ];

--- a/src/RequestHasher.php
+++ b/src/RequestHasher.php
@@ -17,8 +17,10 @@ class RequestHasher
 
     public function getHashFor(Request $request): string
     {
-        return 'responsecache-'.md5(
-            "{$request->getRequestUri()}/{$request->getMethod()}/".$this->cacheProfile->cacheNameSuffix($request)
-        );
+        $cacheNameSuffix = $this->cacheProfile->cacheNameSuffix($request);
+
+        return $cacheNameSuffix . '-responsecache-'.md5(
+                "{$request->getRequestUri()}/{$request->getMethod()}/". $cacheNameSuffix
+            );
     }
 }

--- a/src/RequestHasher.php
+++ b/src/RequestHasher.php
@@ -17,10 +17,8 @@ class RequestHasher
 
     public function getHashFor(Request $request): string
     {
-        $cacheNameSuffix = $this->cacheProfile->cacheNameSuffix($request);
-
-        return $cacheNameSuffix . '-responsecache-'.md5(
-                "{$request->getRequestUri()}/{$request->getMethod()}/". $cacheNameSuffix
+        return 'responsecache-'.md5(
+                "{$request->getRequestUri()}/{$request->getMethod()}/". $this->cacheProfile->cacheNameSuffix($request)
             );
     }
 }

--- a/src/ResponseCacheRepository.php
+++ b/src/ResponseCacheRepository.php
@@ -9,6 +9,8 @@ class ResponseCacheRepository
 {
     /** @var \Illuminate\Cache\Repository */
     protected $cache;
+    
+    protected $cacheTag;
 
     /** @var \Spatie\ResponseCache\ResponseSerializer */
     protected $responseSerializer;
@@ -17,26 +19,44 @@ class ResponseCacheRepository
     {
         $this->cache = $cache;
         $this->responseSerializer = $responseSerializer;
+        $this->cacheTag = config('responsecache.cache_tag', 'responsecache');;
     }
 
     /**
+     * @param string $cacheNameSuffix
      * @param string $key
      * @param \Symfony\Component\HttpFoundation\Response $response
      * @param \DateTime|int $minutes
      */
-    public function put(string $key, $response, $minutes)
+    public function put(string $cacheNameSuffix, string $key, $response, $minutes)
     {
-        $this->cache->put($key, $this->responseSerializer->serialize($response), $minutes);
+        $value = $this->responseSerializer->serialize($response);
+
+        if (method_exists($this->cache->getStore(), 'tags')) {
+            \Cache::tags([$this->cacheTag, $cacheNameSuffix])->put($key, $value, $minutes);
+        } else {
+            $this->cache->put($key, $value, $minutes);
+        }
     }
 
-    public function has(string $key): bool
+    public function has(string $key, string $prefix = null): bool
     {
-        return $this->cache->has($key);
+        if (method_exists($this->cache->getStore(), 'tags')) {
+            return !is_null( \Cache::tags([$this->cacheTag, $prefix])->get($key));
+        } else {
+            return $this->cache->has($key);
+        }
     }
 
-    public function get(string $key): Response
+    public function get(string $key, string $prefix = null): Response
     {
-        return $this->responseSerializer->unserialize($this->cache->get($key));
+        if (method_exists($this->cache->getStore(), 'tags')) {
+            $serializedResponse = \Cache::tags([$this->cacheTag, $prefix])->get($key);
+        } else {
+            $serializedResponse = $this->cache->get($key);
+        }
+        
+        return $this->responseSerializer->unserialize($serializedResponse);
     }
 
     /**
@@ -52,8 +72,13 @@ class ResponseCacheRepository
         $this->cache->flush();
     }
 
-    public function forget(string $key): bool
+    public function forget(string $key = null, string $prefix = null): bool
     {
-        return $this->cache->forget($key);
+        if (method_exists($this->cache->getStore(), 'tags')) {
+            \Cache::tags([$this->cacheTag, $prefix])->forget($key);
+            return true;
+        } else {
+            return $this->cache->forget($key);
+        }
     }
 }


### PR DESCRIPTION
Sometimes it's crucial to have an option to delete all cache items for all the requests for the particular user.

It can be useful especially when there are no other options to delete cache for all possible URLs related to the same base URL. 

For instance, you may have base URL /api/article and you may also support query parameter names following the [JSON API](https://jsonapi.org/) specification which means that client may request your API via dynamic query parameters and as the result, each unique request will produce new cache item being created. 

```
/api/article/?filter[category_id]=1&filter[author_id]=1
/api/article/?filter[category_id]=1&filter[author_id]=2
/api/article/?filter[category_id]=2&filter[author_id]=1
...

```
At this point, you can't delete such cache items because we store cache by md5 based hash of the request+query params+prefix and we can't guess what  possible hashes are. 

The only way is to remove all cache for the particular user using the power of cache tags when supported. We simply create cache as tag [cache_tag, prefix] and then when we are able to delete cache for that prefix.