### PR TITLE
Laravel 5.8 cache TTL regression fix

### DIFF
--- a/config/responsecache.php
+++ b/config/responsecache.php
@@ -19,7 +19,7 @@ return [
      * When using the default CacheRequestFilter this setting controls the
      * default number of seconds responses must be cached.
      */
-    'cache_lifetime_in_seconds' => env('RESPONSE_CACHE_LIFETIME', 60 * 24 * 7),
+    'cache_lifetime_in_seconds' => env('RESPONSE_CACHE_LIFETIME', 60 * 60 * 24 * 7),
 
     /*
      * This setting determines if a http header named "Laravel-responsecache"


### PR DESCRIPTION
Laravel 5.8 changed caching arguments to seconds instead of minutes. The variable name was changed to reflect this, but the value was not. This causes the default cache lifetime to be `168 minutes` instead of 7 days.