### PR TITLE
Included host for creating request hash

### DIFF
--- a/src/RequestHasher.php
+++ b/src/RequestHasher.php
@@ -18,7 +18,7 @@ class RequestHasher
     public function getHashFor(Request $request): string
     {
         return 'responsecache-'.md5(
-            "{$request->getRequestUri()}/{$request->getMethod()}/".$this->cacheProfile->cacheNameSuffix($request)
+            "{$request->getHost()}/{$request->getRequestUri()}/{$request->getMethod()}/".$this->cacheProfile->cacheNameSuffix($request)
         );
     }
 }

--- a/tests/ResponseHasherTest.php
+++ b/tests/ResponseHasherTest.php
@@ -36,7 +36,7 @@ class ResponseHasherTest extends TestCase
     {
         $this->cacheProfile->shouldReceive('cacheNameSuffix')->andReturn('cacheProfileSuffix');
 
-        $this->assertEquals('responsecache-1906a94776759c109dba2177825ade33',
+        $this->assertEquals('responsecache-4d4ecd81770e6753c5fab1dd274f7b45',
             $this->requestHasher->getHashFor($this->request));
     }
 }

--- a/tests/ResponseHasherTest.php
+++ b/tests/ResponseHasherTest.php
@@ -39,4 +39,16 @@ class ResponseHasherTest extends TestCase
         $this->assertEquals('responsecache-4d4ecd81770e6753c5fab1dd274f7b45',
             $this->requestHasher->getHashFor($this->request));
     }
+
+    /** @test */
+    public function it_generates_a_different_hash_per_request_host()
+    {
+        $this->cacheProfile->shouldReceive('cacheNameSuffix')->andReturn('cacheProfileSuffix');
+
+        $request = Request::create('https://spatie.be/example-page');
+        $requestForSubdomain = Request::create('https://de.spatie.be/example-page');
+
+        $this->assertNotEquals($this->requestHasher->getHashFor($request),
+            $this->requestHasher->getHashFor($requestForSubdomain));
+    }
 }


### PR DESCRIPTION
I have a project running on multiple domains per locale. This fixes the incorrect caching for such cases. For instance, example.org/u/1 and de.example.org/u/1 should be cached separately.