### PR TITLE
Route Specific Tagging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: php
 
+services:
+    - redis-server
+
 cache:
     directories:
         - $HOME/.composer/cache

--- a/README.md
+++ b/README.md
@@ -244,6 +244,44 @@ Route::group(function() {
 })->middleware('cacheResponse:600');
 ```
 
+### Tagging Routes
+
+If the cache driver you configured supports tags, you can specify a list of tags when applying the middleware:
+
+```php
+// add a "snowflake" tag to this route
+Route::get('/my-special-snowflake', 'SnowflakeController@index')->middleware('cacheResponse:,snowflake');
+
+// add both "special" and "snowflake" tags to these routes
+Route::group(function() {
+   Route::get('/another-special-snowflake', 'AnotherSnowflakeController@index');
+
+   Route::get('/yet-another-special-snowflake', 'YetAnotherSnowflakeController@index');
+})->middleware('cacheResponse:,special,snowflake');
+```
+
+#### Clearing Tagged Routes
+
+You can clear responses which are assigned a tag or list of tags. For example, this statement would remove all routes 
+specified above:
+
+```php
+ResponseCache::clear(['special', 'snowflake']);
+```
+
+In contrast, this statement would remove only the grouped routes, but not the `'/my-special-snowflake'` route:
+
+```php
+ResponseCache::clear('special');
+```
+
+Note that this uses [Laravel's built in cache tags](https://laravel.com/docs/master/cache#cache-tags) functionality, meaning 
+routes can also be cleared in the usual way:
+
+```php
+Cache::tags('special')->flush();
+```
+
 ### Events
 
 There are several events you can use to monitor and debug response caching in your application.

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
     "require-dev": {
         "phpunit/phpunit" : "^8.0",
         "orchestra/testbench": "~3.8.0",
-        "mockery/mockery": "^1.0"
+        "mockery/mockery": "^1.0",
+        "predis/predis": "^1.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/Middlewares/CacheResponse.php
+++ b/src/Middlewares/CacheResponse.php
@@ -23,7 +23,7 @@ class CacheResponse
 
     public function handle(Request $request, Closure $next, $lifetimeInSeconds = null, ...$tags): Response
     {
-        $lifetimeInSeconds === "" ? null : $lifetimeInSeconds;
+        $lifetimeInSeconds === '' ? null : $lifetimeInSeconds;
 
         if ($this->responseCache->enabled($request)) {
             if ($this->responseCache->hasBeenCached($request, $tags)) {
@@ -40,7 +40,7 @@ class CacheResponse
         }
 
         $response = $next($request);
-       
+
         if ($this->responseCache->enabled($request)) {
             if ($this->responseCache->shouldCache($request, $response)) {
                 $this->makeReplacementsAndCacheResponse($request, $response, $lifetimeInSeconds, $tags);

--- a/src/ResponseCacheRepository.php
+++ b/src/ResponseCacheRepository.php
@@ -3,6 +3,7 @@
 namespace Spatie\ResponseCache;
 
 use Illuminate\Cache\Repository;
+use Illuminate\Cache\TaggedCache;
 use Symfony\Component\HttpFoundation\Response;
 
 class ResponseCacheRepository
@@ -48,5 +49,14 @@ class ResponseCacheRepository
     public function forget(string $key): bool
     {
         return $this->cache->forget($key);
+    }
+
+    /**
+     * @param  array|mixed  $names
+     * @return \Illuminate\Cache\TaggedCache
+     */
+    public function tags($names): TaggedCache
+    {
+        return $this->cache->tags($names);
     }
 }

--- a/tests/TagTest.php
+++ b/tests/TagTest.php
@@ -16,8 +16,8 @@ class TagTest extends TestCase
     {
         parent::getEnvironmentSetUp($app);
 
-        $app['config']->set('cache.driver', 'redis');
         // Set the driver to redis (tags don't work with the file driver)
+        $app['config']->set('cache.driver', 'redis');
         $app['config']->set('responsecache.cache_store', 'redis');
         // Before running the test, we have to clear the redis cache of any
         // previously cached responses. Setting the cache_tag scopes the
@@ -48,7 +48,7 @@ class TagTest extends TestCase
     {
         $firstResponse = $this->call('GET', '/tagged/1');
         $this->assertRegularResponse($firstResponse);
-        
+
         $this->app['responsecache']->clear('foo');
 
         $secondResponse = $this->call('GET', '/tagged/1');

--- a/tests/TagTest.php
+++ b/tests/TagTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Spatie\ResponseCache\Test;
+
+class TagTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    /**
+     * @param \Illuminate\Foundation\Application $app
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('cache.driver', 'redis');
+        // Set the driver to redis (tags don't work with the file driver)
+        $app['config']->set('responsecache.cache_store', 'redis');
+        // Before running the test, we have to clear the redis cache of any
+        // previously cached responses. Setting the cache_tag scopes the
+        // responses to only the ones we want to remove.
+        $app['config']->set('responsecache.cache_tag', 'laravel-responsecache');
+    }
+
+    /** @test */
+    public function it_can_cache_requests_using_route_cache_tags()
+    {
+        $firstResponse = $this->call('GET', '/tagged/1');
+        $this->assertRegularResponse($firstResponse);
+
+        $secondResponse = $this->call('GET', '/tagged/1');
+        $this->assertCachedResponse($secondResponse);
+        $this->assertSameResponse($firstResponse, $secondResponse);
+
+        $thirdResponse = $this->call('GET', '/tagged/2');
+        $this->assertRegularResponse($thirdResponse);
+
+        $fourthResponse = $this->call('GET', '/tagged/2');
+        $this->assertCachedResponse($fourthResponse);
+        $this->assertSameResponse($thirdResponse, $fourthResponse);
+    }
+
+    /** @test */
+    public function it_can_forget_requests_using_route_cache_tags()
+    {
+        $firstResponse = $this->call('GET', '/tagged/1');
+        $this->assertRegularResponse($firstResponse);
+        
+        $this->app['responsecache']->clear('foo');
+
+        $secondResponse = $this->call('GET', '/tagged/1');
+        $this->assertRegularResponse($secondResponse);
+        $this->assertDifferentResponse($firstResponse, $secondResponse);
+
+        $this->app['responsecache']->clear();
+
+        $thirdResponse = $this->call('GET', '/tagged/1');
+        $this->assertRegularResponse($thirdResponse);
+        $this->assertDifferentResponse($secondResponse, $thirdResponse);
+    }
+
+    /** @test */
+    public function it_can_forget_requests_using_route_cache_tags_from_global_cache()
+    {
+        $firstResponse = $this->call('GET', '/tagged/1');
+        $this->assertRegularResponse($firstResponse);
+
+        $this->app['cache']->store(config('responsecache.cache_store'))->tags('laravel-responsecache')->clear('foo');
+
+        $secondResponse = $this->call('GET', '/tagged/1');
+        $this->assertRegularResponse($secondResponse);
+        $this->assertDifferentResponse($firstResponse, $secondResponse);
+    }
+
+    /** @test */
+    public function it_can_forget_requests_using_multiple_route_cache_tags()
+    {
+        $firstResponse = $this->call('GET', '/tagged/2');
+        $this->assertRegularResponse($firstResponse);
+
+        $this->app['responsecache']->clear('bar');
+
+        $secondResponse = $this->call('GET', '/tagged/2');
+        $this->assertRegularResponse($secondResponse);
+        $this->assertDifferentResponse($firstResponse, $secondResponse);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -138,6 +138,14 @@ abstract class TestCase extends Orchestra
         Route::any('/cache-for-given-lifetime', function () {
             return 'dummy response';
         })->middleware('cacheResponse:300');
+
+        Route::any('/tagged/1', function () {
+            return Str::random();
+        })->middleware('cacheResponse:,foo');
+
+        Route::any('/tagged/2', function () {
+            return Str::random();
+        })->middleware('cacheResponse:,foo,bar');
     }
 
     public function getTempDirectory($suffix = '')


### PR DESCRIPTION
See #159 

Notes

 - This introduces `predis/predis` as a dev-dependency in order to test tags since the file driver does not support tags. If this is undesirable, it should be possible achieve similar results using a mock which I'll happily look into.

- If there is no global tag (i.e. `responsecache.cache_tag` is null) then `ResponseCache::clear('foo');` is equivalent to `Cache::tags('foo')->flush();` - it runs not only on the response cache but on the entire cache store as specified in the config. This is already mentioned in the readme under "Clearing the Cache", so I assume this is expected.

I'm more than happy to make any changes if need be. Thanks for your continued work on this great package! 👍