### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ interface CacheProfile
      *
      * @return mixed
      */
-    public function cacheNameSuffix(Request $request);
+    public function useCacheNameSuffix(Request $request);
 }
 ```
 


### PR DESCRIPTION
In v6, the cacheNameSuffix function is changed to useCacheNameSuffix