### PR TITLE
Use Auth::id() instead of Auth::user()->id

### DIFF
--- a/src/CacheProfiles/BaseCacheProfile.php
+++ b/src/CacheProfiles/BaseCacheProfile.php
@@ -24,7 +24,7 @@ abstract class BaseCacheProfile implements CacheProfile
     public function useCacheNameSuffix(Request $request): string
     {
         if (Auth::check()) {
-            return Auth::user()->id;
+            return Auth::id();
         }
 
         return '';


### PR DESCRIPTION
This PR allows greater flexibility when using other authentication drivers by requesting the users ID via `Authenticatable::getAuthIdentifier()` through the `Auth` facade.