### PR TITLE
feat: allow header customisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,17 @@ return [
     'cache_lifetime_in_seconds' => env('RESPONSE_CACHE_LIFETIME', 60 * 60 * 24 * 7),
 
     /*
-     * This setting determines if a http header named "Laravel-responsecache"
-     * with the cache time should be added to a cached response. This
-     * can be handy when debugging.
+     * This setting determines if a http header named with the cache time
+     * should be added to a cached response. This can be handy when
+     * debugging.
      */
     'add_cache_time_header' => env('APP_DEBUG', true),
+
+    /*
+     * This setting determines the name of the http header that contains
+     * the time at which the response was cached
+     */
+    'cache_time_header_name' => env('RESPONSE_CACHE_HEADER_NAME', 'laravel-responsecache'),
 
     /*
      * Here you may define the cache store that should be used to store

--- a/config/responsecache.php
+++ b/config/responsecache.php
@@ -22,11 +22,17 @@ return [
     'cache_lifetime_in_seconds' => env('RESPONSE_CACHE_LIFETIME', 60 * 60 * 24 * 7),
 
     /*
-     * This setting determines if a http header named "Laravel-responsecache"
-     * with the cache time should be added to a cached response. This
-     * can be handy when debugging.
+     * This setting determines if a http header named with the cache time
+     * should be added to a cached response. This can be handy when
+     * debugging.
      */
     'add_cache_time_header' => env('APP_DEBUG', true),
+
+    /*
+     * This setting determines the name of the http header that contains
+     * the time at which the response was cached
+     */
+    'cache_time_header_name' => env('RESPONSE_CACHE_HEADER_NAME', 'laravel-responsecache'),
 
     /*
      * Here you may define the cache store that should be used to store

--- a/src/ResponseCache.php
+++ b/src/ResponseCache.php
@@ -4,7 +4,6 @@ namespace Spatie\ResponseCache;
 
 use Carbon\CarbonImmutable;
 use Illuminate\Http\Request;
-use Spatie\ResponseCache\Hasher\DefaultHasher;
 use Spatie\ResponseCache\Hasher\RequestHasher;
 use Symfony\Component\HttpFoundation\Response;
 use Spatie\ResponseCache\CacheProfiles\CacheProfile;
@@ -52,7 +51,7 @@ class ResponseCache
         }
 
         $lifetimeInSeconds = $lifetimeInSeconds
-            ? (int)$lifetimeInSeconds
+            ? (int) $lifetimeInSeconds
             : $this->cacheProfile->cacheRequestUntil($request);
 
         $this->cache->put(

--- a/src/ResponseCache.php
+++ b/src/ResponseCache.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\ResponseCache;
 
+use Carbon\CarbonImmutable;
 use Illuminate\Http\Request;
 use Spatie\ResponseCache\Hasher\DefaultHasher;
 use Spatie\ResponseCache\Hasher\RequestHasher;
@@ -84,7 +85,10 @@ class ResponseCache
     {
         $clonedResponse = clone $response;
 
-        $clonedResponse->headers->set('laravel-responsecache', 'cached on '.date('Y-m-d H:i:s'));
+        $clonedResponse->headers->set(
+            config('responsecache.cache_time_header_name'),
+            CarbonImmutable::now()->toRfc2822String(),
+        );
 
         return $clonedResponse;
     }

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\ResponseCache\Test;
 
 use Carbon\Carbon;
+use DateTime;
 use ResponseCache;
 use Illuminate\Support\Facades\Event;
 use Spatie\ResponseCache\Events\CacheMissed;
@@ -255,5 +256,21 @@ class IntegrationTest extends TestCase
         Carbon::setTestNow();
         $thirdResponse = $this->call('get', '/cache-for-given-lifetime');
         $this->assertRegularResponse($thirdResponse);
+    }
+
+    /** @test */
+    public function it_can_add_a_cache_time_header()
+    {
+        $this->app['config']->set('responsecache.add_cache_time_header', true);
+        $this->app['config']->set('responsecache.cache_time_header_name', 'X-Cached-At');
+
+        $firstResponse = $this->call('get', '/random');
+        $secondResponse = $this->call('get', '/random');
+
+        $this->assertFalse($firstResponse->headers->has('X-Cached-At'));
+        $this->assertTrue($secondResponse->headers->has('X-Cached-At'));
+        $this->assertInstanceOf(DateTime::class, $secondResponse->headers->getDate('X-Cached-At'));
+
+        $this->assertSameResponse($firstResponse, $secondResponse);
     }
 }

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -2,8 +2,8 @@
 
 namespace Spatie\ResponseCache\Test;
 
-use Carbon\Carbon;
 use DateTime;
+use Carbon\Carbon;
 use ResponseCache;
 use Illuminate\Support\Facades\Event;
 use Spatie\ResponseCache\Events\CacheMissed;


### PR DESCRIPTION
Currently you can't set the header name for cache time header. Unfortunately the default header isn't correctly prefixed to be used on production.

I've updated it so that the header name can be configured. 
I also changed the content of the header to a RFC 2822 format string, as it's the one usually used in HTTP headers, which makes parsing the header much easier versus the string.

Let me know you thoughts 😄 