### PR TITLE
fix: cache json responses

### DIFF
--- a/src/CacheProfiles/CacheAllSuccessfulGetRequests.php
+++ b/src/CacheProfiles/CacheAllSuccessfulGetRequests.php
@@ -51,6 +51,6 @@ class CacheAllSuccessfulGetRequests extends BaseCacheProfile
     {
         $contentType = $response->headers->get('Content-Type', '');
 
-        return Str::startsWith($contentType, 'text');
+        return Str::startsWith($contentType, 'text') || Str::contains($contentType, 'application/json');
     }
 }

--- a/tests/CacheProfiles/CacheAllSuccessfulGetRequestsTest.php
+++ b/tests/CacheProfiles/CacheAllSuccessfulGetRequestsTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\ResponseCache\Test\CacheProfiles;
 
 use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
 use Spatie\ResponseCache\Test\User;
 use Spatie\ResponseCache\Test\TestCase;
 use Symfony\Component\HttpFoundation\Response;
@@ -50,6 +51,16 @@ class CacheAllSuccessfulGetRequestsTest extends TestCase
         $shouldCacheResponse = $this->cacheProfile->shouldCacheResponse($response);
 
         $this->assertFalse($shouldCacheResponse);
+    }
+
+    /** @test */
+    public function it_will_determine_that_a_json_response_should_be_cached()
+    {
+        $response = new JsonResponse(['a' => 'b']);
+
+        $shouldCacheResponse = $this->cacheProfile->shouldCacheResponse($response);
+
+        $this->assertTrue($shouldCacheResponse);
     }
 
     /** @test */


### PR DESCRIPTION
This adds `application/json` to the allowed content types in the default cache profile, as it was missing as per #231 

Closes #231 