### PR TITLE
Update Readme for cache_lifetime_in_minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ return [
      * When using the default CacheRequestFilter this setting controls the
      * default number of seconds responses must be cached.
      */
-    'cache_lifetime_in_seconds' => env('RESPONSE_CACHE_LIFETIME', 60 * 60 * 24 * 7),
+    'cache_lifetime_in_minutes' => env('RESPONSE_CACHE_LIFETIME', 60 * 24 * 7),
 
     /*
      * This setting determines if a http header named with the cache time


### PR DESCRIPTION
cache_lifetime_in_minutes comes with new Laravel 5.8 Cache TTL, so it's better to fix readme too