### PR TITLE
Syntax error fix

### DIFF
--- a/src/ResponseCache.php
+++ b/src/ResponseCache.php
@@ -56,7 +56,7 @@ class ResponseCache
         $this->taggedCache($tags)->put(
             $this->hasher->getHashFor($request),
             $response,
-            $lifetimeInSeconds ?? $this->cacheProfile->cacheRequestUntil($request),
+            $lifetimeInSeconds ?? $this->cacheProfile->cacheRequestUntil($request)
         );
 
         return $response;


### PR DESCRIPTION
I'm not sure how no one is affected by this or how build passed but I immediately got this syntax error upon installation:

```
ReflectionException
Class Spatie\ResponseCache\ResponseCache does not exist

Previous exceptions
syntax error, unexpected ')' (0)
```

This change fixed it for me?

PHP 7.1.23
Laravel 5.8.31