### PR TITLE
Customizable serializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ return [
     'replacers' => [
         \Spatie\ResponseCache\Replacers\CsrfTokenReplacer::class,
     ],
-    
+
     /*
      * If the cache driver you configured supports tags, you may specify a tag name
      * here. All responses will be tagged. When clearing the responsecache only
@@ -88,12 +88,18 @@ return [
      * You may use a string or an array here.
      */
     'cache_tag' => '',
-    
+
     /*
      * This class is responsible for generating a hash for a request. This hash
      * is used to look up an cached response.
      */
     'hasher' => \Spatie\ResponseCache\Hasher\DefaultHasher::class,
+
+    /*
+     * This class serializes cache data and expands it.
+     * Serialization can save the data to be returned in an appropriate form.
+     */
+    'serializer' => \Spatie\ResponseCache\Serializer\DefaultSerializer::class,
 ];
 ```
 
@@ -147,7 +153,7 @@ The same can be accomplished by issuing this artisan command:
 php artisan responsecache:clear
 ```
 
-#### Using model events 
+#### Using model events
 
 You can leverage model events to clear the cache whenever a model is saved or deleted. Here's an example.
 ```php
@@ -385,6 +391,27 @@ Afterwards you can define your replacer in the `responsecache.php` config file:
 'replacers' => [
     \Spatie\ResponseCache\Replacers\CsrfTokenReplacer::class,
 ],
+```
+
+### Customizing Serializer
+
+In order to keep the response data as a cache, it has serialized data inside.
+The default provided serializer `Spatie\ResponseCache\Serializer\DefaultSerializer` will often work satisfactorily.
+
+However, you may want to serialize according to your requirements.
+As an example, in `ExampleSerializer`, the response data returned by your service is cached in strict type.
+
+By inheriting `DefaultSerializer` and changing only the necessary parts, you can easily customize it.
+Of course, you can implement it from scratch.
+
+Once you have implemented the Serializable interface in your serializer, specify it in the config file.
+
+```
+/*
+ * This class serializes cache data and expands it.
+ * Serialization can save the data to be returned in an appropriate form.
+ */
+'serializer' => \Spatie\ResponseCache\Serializer\ExampleSerializer::class,
 ```
 
 ## Changelog

--- a/config/responsecache.php
+++ b/config/responsecache.php
@@ -63,4 +63,10 @@ return [
      * is used to look up an cached response.
      */
     'hasher' => \Spatie\ResponseCache\Hasher\DefaultHasher::class,
+
+    /*
+     * This class serializes cache data and expands it.
+     * Serialization can save the data to be returned in an appropriate form.
+     */
+    'serializer' => \Spatie\ResponseCache\Serializer\DefaultSerializer::class,
 ];

--- a/src/ResponseCacheRepository.php
+++ b/src/ResponseCacheRepository.php
@@ -4,6 +4,7 @@ namespace Spatie\ResponseCache;
 
 use Illuminate\Cache\Repository;
 use Symfony\Component\HttpFoundation\Response;
+use Spatie\ResponseCache\Serializer\Serializable;
 
 class ResponseCacheRepository
 {
@@ -13,7 +14,7 @@ class ResponseCacheRepository
     /** @var \Spatie\ResponseCache\ResponseSerializer */
     protected $responseSerializer;
 
-    public function __construct(ResponseSerializer $responseSerializer, Repository $cache)
+    public function __construct(Serializable $responseSerializer, Repository $cache)
     {
         $this->cache = $cache;
 

--- a/src/ResponseCacheServiceProvider.php
+++ b/src/ResponseCacheServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Container\Container;
 use Illuminate\Support\ServiceProvider;
 use Spatie\ResponseCache\Hasher\RequestHasher;
 use Spatie\ResponseCache\Commands\ClearCommand;
+use Spatie\ResponseCache\Serializer\Serializable;
 use Spatie\ResponseCache\CacheProfiles\CacheProfile;
 
 class ResponseCacheServiceProvider extends ServiceProvider
@@ -23,6 +24,10 @@ class ResponseCacheServiceProvider extends ServiceProvider
 
         $this->app->bind(RequestHasher::class, function (Container $app) {
             return $app->make(config('responsecache.hasher'));
+        });
+
+        $this->app->bind(Serializable::class, function (Container $app) {
+            return $app->make(config('responsecache.serializer'));
         });
 
         $this->app->when(ResponseCacheRepository::class)

--- a/src/Serializer/DefaultSerializer.php
+++ b/src/Serializer/DefaultSerializer.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Spatie\ResponseCache;
+namespace Spatie\ResponseCache\Serializer;
 
 use Symfony\Component\HttpFoundation\Response;
 use Illuminate\Http\Response as IlluminateResponse;
 use Spatie\ResponseCache\Exceptions\CouldNotUnserialize;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
-class ResponseSerializer
+class DefaultSerializer implements Serializable
 {
     public const RESPONSE_TYPE_NORMAL = 'response_type_normal';
     public const RESPONSE_TYPE_FILE = 'response_type_file';

--- a/src/Serializer/ExampleSerializer.php
+++ b/src/Serializer/ExampleSerializer.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Spatie\ResponseCache\Serializer;
+
+use Illuminate\Http\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+class ExampleSerializer extends DefaultSerializer
+{
+    protected function getResponseData(Response $response): array
+    {
+        $statusCode = $response->getStatusCode();
+        $headers = $response->headers;
+
+        if ($response instanceof BinaryFileResponse) {
+            $content = $response->getFile()->getPathname();
+            $type = self::RESPONSE_TYPE_FILE;
+
+            return compact('statusCode', 'headers', 'content', 'type');
+        }
+
+        // If you return it with JsonResponse, save the content as JSON
+        $content = $response instanceof JsonResponse
+            ? $response->getData()
+            : $response->getContent();
+
+        $type = self::RESPONSE_TYPE_NORMAL;
+
+        // Save class name
+        $class = get_class($response);
+
+        return compact('statusCode', 'headers', 'content', 'type', 'class');
+    }
+
+    protected function buildResponse(array $responseProperties): Response
+    {
+        $type = $responseProperties['type'] ?? self::RESPONSE_TYPE_NORMAL;
+
+        if ($type === self::RESPONSE_TYPE_FILE) {
+            return new BinaryFileResponse(
+                $responseProperties['content'],
+                $responseProperties['statusCode']
+            );
+        }
+
+        $class = $responseProperties['class'];
+
+        // Restore as saved class
+        return new $class($responseProperties['content'], $responseProperties['statusCode']);
+    }
+}

--- a/src/Serializer/Serializable.php
+++ b/src/Serializer/Serializable.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Spatie\ResponseCache\Serializer;
+
+use Symfony\Component\HttpFoundation\Response;
+
+interface Serializable
+{
+    public function serialize(Response $response): string;
+
+    public function unserialize(string $serializedResponse): Response;
+}

--- a/tests/ResponseSerializerTest.php
+++ b/tests/ResponseSerializerTest.php
@@ -2,17 +2,20 @@
 
 namespace Spatie\ResponseCache\Test;
 
-use Spatie\ResponseCache\ResponseSerializer;
-use Symfony\Component\HttpFoundation\Response;
+use Config;
+use Illuminate\Http\Response;
+use Illuminate\Http\JsonResponse;
+use Spatie\ResponseCache\Serializer\Serializable;
+use Spatie\ResponseCache\Serializer\ExampleSerializer;
 use Spatie\ResponseCache\Exceptions\CouldNotUnserialize;
 
 class ResponseSerializerTest extends TestCase
 {
-    /** @var \Spatie\ResponseCache\ResponseSerializer */
-    protected $responseSerializer;
+    /** @var string */
+    protected $textContent;
 
     /** @var string */
-    protected $content;
+    protected $jsonContent;
 
     /** @var string */
     protected $statusCode;
@@ -21,9 +24,8 @@ class ResponseSerializerTest extends TestCase
     {
         parent::setUp();
 
-        $this->responseSerializer = new ResponseSerializer();
-
-        $this->content = '<html>This is a response</html>';
+        $this->textContent = '<html>This is a response</html>';
+        $this->jsonContent = json_encode(['text' => 'This is a response']);
 
         $this->statusCode = 500;
     }
@@ -31,17 +33,48 @@ class ResponseSerializerTest extends TestCase
     /** @test */
     public function it_can_serialize_and_unserialize_a_response()
     {
-        $testResponse = Response::create($this->content, $this->statusCode, ['testHeader' => 'testValue']);
+        // Instantiate a default serializer
+        $responseSerializer = app(Serializable::class);
 
-        $serializedResponse = $this->responseSerializer->serialize($testResponse);
+        $testResponse = Response::create(
+            $this->textContent, $this->statusCode, ['testHeader' => 'testValue']);
+
+        $serializedResponse = $responseSerializer->serialize($testResponse);
 
         $this->assertTrue(is_string($serializedResponse));
 
-        $unserializedResponse = $this->responseSerializer->unserialize($serializedResponse);
+        $unserializedResponse = $responseSerializer->unserialize($serializedResponse);
 
         $this->assertInstanceOf(Response::class, $unserializedResponse);
 
-        $this->assertEquals($this->content, $unserializedResponse->getContent());
+        $this->assertEquals($this->textContent, $unserializedResponse->getContent());
+
+        $this->assertEquals($this->statusCode, $unserializedResponse->getStatusCode());
+
+        $this->assertEquals('testValue', $unserializedResponse->headers->get('testHeader'));
+    }
+
+    /** @test */
+    public function it_can_customized_serialize_and_unserialize_a_response()
+    {
+        // Set config dynamically for test
+        Config::set('responsecache.serializer', ExampleSerializer::class);
+
+        // Instantiate a custom serializer according to config
+        $responseSerializer = app(Serializable::class);
+
+        $testResponse = JsonResponse::create(
+            $this->jsonContent, $this->statusCode, ['testHeader' => 'testValue']);
+
+        $serializedResponse = $responseSerializer->serialize($testResponse);
+
+        $this->assertTrue(is_string($serializedResponse));
+
+        $unserializedResponse = $responseSerializer->unserialize($serializedResponse);
+
+        $this->assertInstanceOf(JsonResponse::class, $unserializedResponse);
+
+        $this->assertEquals($this->jsonContent, $unserializedResponse->getData());
 
         $this->assertEquals($this->statusCode, $unserializedResponse->getStatusCode());
 
@@ -53,6 +86,6 @@ class ResponseSerializerTest extends TestCase
     {
         $this->expectException(CouldNotUnserialize::class);
 
-        $this->responseSerializer->unserialize('b:0;');
+        app(Serializable::class)->unserialize('b:0;');
     }
 }


### PR DESCRIPTION
As shown in #243, the serializer can be replaced.

**Supplemental remarks**

- Response type in test
The response type of the test was changed because Illuminate was more practical than Symfony.

- Poor my English
I'm not good at English, so I would appreciate it if you corrected it as needed.
