### PR TITLE
Fix syntax errors -  unexpected ')'

### DIFF
--- a/src/ResponseCache.php
+++ b/src/ResponseCache.php
@@ -56,7 +56,7 @@ class ResponseCache
         $this->taggedCache($tags)->put(
             $this->hasher->getHashFor($request),
             $response,
-            $lifetimeInSeconds ?? $this->cacheProfile->cacheRequestUntil($request),
+            $lifetimeInSeconds ?? $this->cacheProfile->cacheRequestUntil($request)
         );
 
         return $response;
@@ -85,7 +85,7 @@ class ResponseCache
 
         $clonedResponse->headers->set(
             config('responsecache.cache_time_header_name'),
-            now()->toRfc2822String(),
+            now()->toRfc2822String()
         );
 
         return $clonedResponse;


### PR DESCRIPTION
Using PHP 7.3 i'm getting the following errors:

`ERROR: syntax error, unexpected ')' {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): syntax error, unexpected ')' at ../vendor/spatie/laravel-responsecache/src/ResponseCache.php:60)`

`ERROR: syntax error, unexpected ')' {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): syntax error, unexpected ')' at ../vendor/spatie/laravel-responsecache/src/ResponseCache.php:89)`

This PR fixes those errors.