### PR TITLE
Support datetime modifier syntax for cache lifetime

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,8 @@ When using the route middleware you can specify the number of seconds these rout
 ```php
 // cache this route for 5 minutes
 Route::get('/my-special-snowflake', 'SnowflakeController@index')->middleware('cacheResponse:300');
+// or the same using date modifier syntax
+Route::get('/my-special-snowflake', 'SnowflakeController@index')->middleware('cacheResponse:5mins');
 
 // cache all these routes for 10 minutes
 Route::group(function() {

--- a/src/Middlewares/CacheResponse.php
+++ b/src/Middlewares/CacheResponse.php
@@ -89,8 +89,8 @@ class CacheResponse
         }
 
         if (is_string($lifetime)) {
-            /** @see http://php.net/manual/en/datetime.formats.relative.php */
-            return now()->modify($lifetime)->diffInSeconds() ;
+            /* @see http://php.net/manual/en/datetime.formats.relative.php */
+            return now()->modify($lifetime)->diffInSeconds();
         }
 
         return null;

--- a/src/Middlewares/CacheResponse.php
+++ b/src/Middlewares/CacheResponse.php
@@ -77,8 +77,20 @@ class CacheResponse
 
     protected function getLifetime(array $args): ?int
     {
-        if (count($args) >= 1 && is_numeric($args[0])) {
+        if (count($args) === 0) {
+            return null;
+        }
+
+        /** @var int|string $lifetime */
+        $lifetime = $args[0];
+
+        if (is_numeric($lifetime)) {
             return (int) $args[0];
+        }
+
+        if (is_string($lifetime)) {
+            /** @see http://php.net/manual/en/datetime.formats.relative.php */
+            return now()->modify($lifetime)->diffInSeconds() ;
         }
 
         return null;


### PR DESCRIPTION
Closes #267

This PR adds a new syntax for cache lifetime:
```php
Route::get('/my-special-snowflake', 'SnowflakeController@index')->middleware('cacheResponse:5mins');
Route::get('/my-special-snowflake', 'SnowflakeController@index')->middleware('cacheResponse:2hours');
Route::get('/my-special-snowflake', 'SnowflakeController@index')->middleware('cacheResponse:1week');
Route::get('/my-special-snowflake', 'SnowflakeController@index')->middleware('cacheResponse:tomorrow');
Route::get('/my-special-snowflake', 'SnowflakeController@index')->middleware('cacheResponse:noon');
Route::get('/my-special-snowflake', 'SnowflakeController@index')->middleware('cacheResponse:midnight');
// and even
Route::get('/my-special-snowflake', 'SnowflakeController@index')->middleware('cacheResponse:last day of this month');
Route::get('/my-special-snowflake', 'SnowflakeController@index')->middleware('cacheResponse:first monday of January 2020');
```
_________________________
**UPDATE1**: I see a problem: it's possible to omit lifetime option and use multiple tags:
```php
->middleware('cacheResponse:foo,bar')
```
Currently I don't know a good backward compatible solution. 
__________________________
**UPDATE2**: Currently I think that the best option it to use `\Illuminate\Http\Middleware\SetCacheHeaders`- like syntax for options:
```php
// \Illuminate\Http\Middleware\SetCacheHeaders usage example:
Route::get('/', HomeController::class)->middleware('cache.headers:no-cache;max-age=300;etag');

// CacheResponse usage example:
Route::get('/', HomeController::class)->middleware('responseCache:ttl=1hour;tags=foo,bar');
```

But it's BC (unless someone wants to write a good options parser and support it). I think we can implement it as a new middleware in addition to exiting 2 and deprecate existing `CacheResponse` and remove it in next major release.

Another feature that we can implement using this syntax: specify profile as another option:
```php
// use default profile:
Route::get('/', HomeController::class)->middleware('responseCache:ttl=1hour;tags=foo&bar');

// specify profile explicitly:
Route::get('/', HomeController::class)->middleware('responseCache:ttl=1hour;tags=foo&bar;profile=guests-only');
```

The only problem is usage of `,` as delimiter for tags: we need to replace it by something else in order to don't break middleware params parsing by Laravel. Possible options:
 - `&`
 - `|`
 - `+`
 -  `，` ([fullwidth comma)](https://www.compart.com/en/unicode/U+FF0C) 👎 
Could you please provide some feedback on proposed syntax and feature so I will implement it only if we'll merge it. Thanks a lot!