### PR TITLE
Denoting in composer.json that this package does not work with 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.4",
+        "php": ">=7.3 <7.4",
         "laravel/framework": "^6.0",
         "nesbot/carbon": "^2.0"
     },


### PR DESCRIPTION
When this package attempts to run on php >= 7.4, many errors occur. It should be specified that this package does not work on 7.4, and only 7.3 as it seems is mentioned in many issues.

https://github.com/spatie/laravel-responsecache/issues/264
https://github.com/spatie/laravel-responsecache/issues/261
https://github.com/spatie/laravel-responsecache/pull/237