### PR TITLE
Update readme section on clearing tagged cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,14 +315,13 @@ Route::group(function() {
 
 #### Clearing tagged content
 
-You can clear responses which are assigned a tag or list of tags. For example, this statement would remove all routes 
-specified above:
+You can clear responses which are assigned a tag or list of tags. For example, this statement would remove the `'/test3'` and `'/test4'` routes above:
 
 ```php
 ResponseCache::clear(['foo', 'bar']);
 ```
 
-In contrast, this statement would remove all of the routes except the `'/test1'` route:
+In contrast, this statement would remove only the `'/test2'` route:
 
 ```php
 ResponseCache::clear(['bar']);


### PR DESCRIPTION
This PR corrects the "Clearing tagged content" section in the readme doc.

When using Laravel's cache tagging system, you must specify all tags in the correct order to target the cache that you want. Resolving items out of the cache that have multiple tags by using one, individual tag does not work. 

Please see this Laravel issue for more info: https://github.com/laravel/framework/issues/25234