### PR TITLE
Config sample shows seconds instead of minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ return [
      * When using the default CacheRequestFilter this setting controls the
      * default number of seconds responses must be cached.
      */
-    'cache_lifetime_in_seconds' => env('RESPONSE_CACHE_LIFETIME', 60 * 24 * 7),
+    'cache_lifetime_in_seconds' => env('RESPONSE_CACHE_LIFETIME', 60 * 60 * 24 * 7),
 
     /*
      * This setting determines if a http header named with the cache time


### PR DESCRIPTION
Laravel 5.8 changed caching arguments to seconds instead of minutes. The config was changed to reflect this, but the value in the readme was not. If configured as shown in the readme the default cache lifetime would be `168 minutes` instead of 7 days (as it is in the actual config).