### PR TITLE
Add backward compatibility with PHP 7.3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.4",
+        "php": "^7.3",
         "laravel/framework": "^7.0",
         "nesbot/carbon": "^2.0"
     },

--- a/src/Events/CacheMissed.php
+++ b/src/Events/CacheMissed.php
@@ -6,7 +6,10 @@ use Illuminate\Http\Request;
 
 class CacheMissed
 {
-    public Request $request;
+    /**
+     * @var \Illuminate\Http\Request
+     */
+    public $request;
 
     public function __construct(Request $request)
     {

--- a/src/Events/ResponseCacheHit.php
+++ b/src/Events/ResponseCacheHit.php
@@ -6,7 +6,10 @@ use Illuminate\Http\Request;
 
 class ResponseCacheHit
 {
-    public Request $request;
+    /**
+     * @var \Illuminate\Http\Request
+     */
+    public $request;
 
     public function __construct(Request $request)
     {

--- a/src/Hasher/DefaultHasher.php
+++ b/src/Hasher/DefaultHasher.php
@@ -7,7 +7,10 @@ use Spatie\ResponseCache\CacheProfiles\CacheProfile;
 
 class DefaultHasher implements RequestHasher
 {
-    protected CacheProfile $cacheProfile;
+    /**
+     * @var \Spatie\ResponseCache\CacheProfiles\CacheProfile
+     */
+    protected $cacheProfile;
 
     public function __construct(CacheProfile $cacheProfile)
     {

--- a/src/Middlewares/CacheResponse.php
+++ b/src/Middlewares/CacheResponse.php
@@ -13,7 +13,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 class CacheResponse
 {
-    protected ResponseCache $responseCache;
+    /**
+     * @var \Spatie\ResponseCache\ResponseCache
+     */
+    protected $responseCache;
 
     public function __construct(ResponseCache $responseCache)
     {

--- a/src/Replacers/CsrfTokenReplacer.php
+++ b/src/Replacers/CsrfTokenReplacer.php
@@ -6,7 +6,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 class CsrfTokenReplacer implements Replacer
 {
-    protected string $replacementString = '<laravel-responsecache-csrf-token-here>';
+    /**
+     * @var string
+     */
+    protected $replacementString = '<laravel-responsecache-csrf-token-here>';
 
     public function prepareResponseToCache(Response $response): void
     {

--- a/src/ResponseCache.php
+++ b/src/ResponseCache.php
@@ -9,11 +9,20 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ResponseCache
 {
-    protected ResponseCacheRepository $cache;
+    /**
+     * @var \Spatie\ResponseCache\ResponseCacheRepository
+     */
+    protected $cache;
 
-    protected RequestHasher $hasher;
+    /**
+     * @var \Spatie\ResponseCache\Hasher\RequestHasher
+     */
+    protected $hasher;
 
-    protected CacheProfile $cacheProfile;
+    /**
+     * @var \Spatie\ResponseCache\CacheProfiles\CacheProfile
+     */
+    protected $cacheProfile;
 
     public function __construct(ResponseCacheRepository $cache, RequestHasher $hasher, CacheProfile $cacheProfile)
     {

--- a/src/ResponseCacheRepository.php
+++ b/src/ResponseCacheRepository.php
@@ -8,9 +8,15 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ResponseCacheRepository
 {
-    protected Repository $cache;
+    /**
+     * @var \Illuminate\Cache\Repository
+     */
+    protected $cache;
 
-    protected Serializer $responseSerializer;
+    /**
+     * @var \Spatie\ResponseCache\Serializers\Serializer
+     */
+    protected $responseSerializer;
 
     public function __construct(Serializer $responseSerializer, Repository $cache)
     {

--- a/tests/CacheProfiles/CacheAllSuccessfulGetRequestsTest.php
+++ b/tests/CacheProfiles/CacheAllSuccessfulGetRequestsTest.php
@@ -11,7 +11,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 class CacheAllSuccessfulGetRequestsTest extends TestCase
 {
-    protected CacheAllSuccessfulGetRequests $cacheProfile;
+    /**
+     * @var \Spatie\ResponseCache\CacheProfiles\CacheAllSuccessfulGetRequests
+     */
+    protected $cacheProfile;
 
     public function setUp(): void
     {

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -107,6 +107,7 @@ class IntegrationTest extends TestCase
         $firstResponse = $this->call('GET', '/random');
         $this->assertRegularResponse($firstResponse);
 
+        /// Fails because URLGenerator is not using the updated app.url to build URLs
         ResponseCache::forget('http://spatie.be/random');
 
         $secondResponse = $this->call('GET', '/random');

--- a/tests/ResponseHasherTest.php
+++ b/tests/ResponseHasherTest.php
@@ -9,11 +9,20 @@ use Spatie\ResponseCache\Hasher\DefaultHasher;
 
 class ResponseHasherTest extends TestCase
 {
-    protected DefaultHasher $requestHasher;
+    /**
+     * @var \Spatie\ResponseCache\Hasher\DefaultHasher
+     */
+    protected $requestHasher;
 
-    protected CacheProfile $cacheProfile;
+    /**
+     * @var \Spatie\ResponseCache\CacheProfiles\CacheProfile
+     */
+    protected $cacheProfile;
 
-    protected Request $request;
+    /**
+     * @var \Illuminate\Http\Request
+     */
+    protected $request;
 
     public function setUp(): void
     {

--- a/tests/ResponseSerializerTest.php
+++ b/tests/ResponseSerializerTest.php
@@ -11,11 +11,20 @@ use Spatie\ResponseCache\Test\Serializers\TestSerializer;
 
 class ResponseSerializerTest extends TestCase
 {
-    protected string $textContent;
+    /**
+     * @var string
+     */
+    protected $textContent;
 
-    protected string $jsonContent;
+    /**
+     * @var string
+     */
+    protected $jsonContent;
 
-    protected string $statusCode;
+    /**
+     * @var int|string
+     */
+    protected $statusCode;
 
     public function setUp(): void
     {


### PR DESCRIPTION
Hi @freekmurze , 

What I did was basically remove some type hints and bring back docblocks. So this is basically version 6.6.0 with support for PHP 7.3.

But we have two problems in here:

1) A test (`it_can_forget_a_specific_cached_request_with_full_path`) is not passing because the URLGenerator is not using the updated `app.url`. That's maybe a Laravel bug, but I don't really know if it was supposed to work like that. And looks like we have the same bug on 6.6.0 using PHP 7.4 and Laravel 7. This is a way to reproduce the problem:

```
Psy Shell v0.10.3 (PHP 7.4.0 — cli) by Justin Hileman
>>> config('app.url')
=> "http://laravel.com"
>>> config()->set('app.url', 'http://spatie.be');
=> null
>>> config('app.url')
=> "http://spatie.be"
>>> url('/random')
=> "http://laravel.com/random"
>>>
```

2) The last version of Response Cache where we had PHP 7.3 is **6.4** (and not the previous major: 5.x), but that's also targeting Laravel 6.0. From Laravel 6 to 7 we had some changes in the testing framework structure and I don't know if it's worth to get back to that version of testing. So maybe you could tag a 6.5.5 or something.

Cheers!