### PR TITLE
Support JSON types other than application/json

### DIFF
--- a/src/CacheProfiles/CacheAllSuccessfulGetRequests.php
+++ b/src/CacheProfiles/CacheAllSuccessfulGetRequests.php
@@ -51,11 +51,11 @@ class CacheAllSuccessfulGetRequests extends BaseCacheProfile
     {
         $contentType = $response->headers->get('Content-Type', '');
 
-        if (Str::startsWith($contentType, 'text')) {
+        if (Str::startsWith($contentType, 'text/')) {
             return true;
         }
 
-        if (Str::contains($contentType, 'application/json')) {
+        if (Str::contains($contentType, ['/json', '+json'])) {
             return true;
         }
 


### PR DESCRIPTION
While "application/json" is the most common media-type for JSON content, it is not the only one. There are other types which end in "json"; e.g., "application/vnd.api+json". This change is based on the InteractsWithContentTypes@isJson in Laravel.

This also makes the "text" check stricter by looking for "text/" not just "text". I only see "text/" media types registered with [IANA](https://www.iana.org/assignments/media-types/media-types.xhtml).