### PR TITLE
Replace Laravel/framework with individual packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,15 @@
     ],
     "require": {
         "php": "^7.4",
-        "laravel/framework": "^7.13",
+        "illuminate/cache": "^7.13",
+        "illuminate/container": "^7.13",
+        "illuminate/console": "^7.13",
+        "illuminate/http": "^7.13",
+        "illuminate/support": "^7.13",
         "nesbot/carbon": "^2.35"
     },
     "require-dev": {
+        "laravel/framework": "^7.13",
         "phpunit/phpunit" : "^9.1.5",
         "orchestra/testbench": "^5.2",
         "mockery/mockery": "^1.4",

--- a/src/ResponseCache.php
+++ b/src/ResponseCache.php
@@ -3,6 +3,7 @@
 namespace Spatie\ResponseCache;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
 use Spatie\ResponseCache\CacheProfiles\CacheProfile;
 use Spatie\ResponseCache\Hasher\RequestHasher;
 use Symfony\Component\HttpFoundation\Response;
@@ -82,7 +83,7 @@ class ResponseCache
 
         $clonedResponse->headers->set(
             config('responsecache.cache_time_header_name'),
-            now()->toRfc2822String(),
+            Carbon::now()->toRfc2822String(),
         );
 
         return $clonedResponse;


### PR DESCRIPTION
Rather than depend on the entire laravel framework, instead give
composer.json each Illuminate component needed.

This makes installation in Lumen much easier, as pulling in the
Laravel framework causes issues, however all the required illuminate
components are already there as dependencies of the Lumen framework.

Dev requirements still depend on laravel/framework. This does not cause
any issues when the package is required in a Lumen project as these do
not get pulled in.

The only source code change is to use Carbon::now() rather than the
Laravel now() helper function - to be Laravel / Lumen agnostic.

The provider class can be used as is in Lumen.

If wanted - I can write a 'Installing in Lumen' section for the readme.