### PR TITLE
Fix tagged responsecache:clear

### DIFF
--- a/src/ResponseCacheRepository.php
+++ b/src/ResponseCacheRepository.php
@@ -41,6 +41,10 @@ class ResponseCacheRepository
 
     public function clear()
     {
+        if (! empty(config('responsecache.cache_tag'))) {
+            return $this->cache->tags(config('responsecache.cache_tag'))->flush();
+        }
+
         $this->cache->clear();
     }
 


### PR DESCRIPTION
Fix for flushing from store only the keys tagged by responsecache.

This bug was clearing our whole cache all the time, because we are clearing responsecache every time someone update a model, we lost everything else cached by the application.

Closes https://github.com/spatie/laravel-responsecache/issues/315