### PR TITLE
Fix clear not checking for current tags before using config

### DIFF
--- a/src/ResponseCacheRepository.php
+++ b/src/ResponseCacheRepository.php
@@ -41,7 +41,7 @@ class ResponseCacheRepository
 
     public function clear()
     {
-        if (! empty(config('responsecache.cache_tag'))) {
+        if (empty($this->cache->getTags()) && ! empty(config('responsecache.cache_tag'))) {
             return $this->cache->tags(config('responsecache.cache_tag'))->flush();
         }
 


### PR DESCRIPTION
@freekmurze , this should fix the breaking change introduced by https://github.com/spatie/laravel-responsecache/pull/316. 

The problem was not checking if we already had a cache tag before using the one from config.

Cheers.