### PR TITLE
Fix clear not checking for current tags before using config

### DIFF
--- a/src/ResponseCacheRepository.php
+++ b/src/ResponseCacheRepository.php
@@ -40,13 +40,17 @@ class ResponseCacheRepository
         return $this->responseSerializer->unserialize($this->cache->get($key));
     }
 
-    public function clear()
+    public function clear(): void
     {
-        if (! $this->isTagged($this->cache) && ! empty(config('responsecache.cache_tag'))) {
-            return $this->cache->tags(config('responsecache.cache_tag'))->flush();
+        if ($this->isTagged($this->cache) {
+            $this->cache->clear();
+        }
+            
+        if (empty(config('responsecache.cache_tag')) {
+            $this->cache->clear();
         }
 
-        $this->cache->clear();
+        $this->cache->tags(config('responsecache.cache_tag'))->flush()
     }
 
     public function forget(string $key): bool

--- a/src/ResponseCacheRepository.php
+++ b/src/ResponseCacheRepository.php
@@ -50,7 +50,7 @@ class ResponseCacheRepository
             $this->cache->clear();
         }
 
-        $this->cache->tags(config('responsecache.cache_tag'))->flush()
+        $this->cache->tags(config('responsecache.cache_tag'))->flush();
     }
 
     public function forget(string $key): bool

--- a/src/ResponseCacheRepository.php
+++ b/src/ResponseCacheRepository.php
@@ -42,7 +42,7 @@ class ResponseCacheRepository
 
     public function clear(): void
     {
-        if ($this->isTagged($this->cache) {
+        if ($this->isTagged($this->cache)) {
             $this->cache->clear();
         }
             

--- a/src/ResponseCacheRepository.php
+++ b/src/ResponseCacheRepository.php
@@ -3,6 +3,7 @@
 namespace Spatie\ResponseCache;
 
 use Illuminate\Cache\Repository;
+use Illuminate\Cache\TaggedCache;
 use Spatie\ResponseCache\Serializers\Serializer;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -41,7 +42,7 @@ class ResponseCacheRepository
 
     public function clear()
     {
-        if (! empty(config('responsecache.cache_tag'))) {
+        if (! $this->isTagged($this->cache) && ! empty(config('responsecache.cache_tag'))) {
             return $this->cache->tags(config('responsecache.cache_tag'))->flush();
         }
 
@@ -56,5 +57,10 @@ class ResponseCacheRepository
     public function tags(array $tags): self
     {
         return new self($this->responseSerializer, $this->cache->tags($tags));
+    }
+
+    public function isTagged($repository): bool
+    {
+        return $repository instanceof TaggedCache && ! empty($repository->getTags());
     }
 }

--- a/src/ResponseCacheRepository.php
+++ b/src/ResponseCacheRepository.php
@@ -46,7 +46,7 @@ class ResponseCacheRepository
             $this->cache->clear();
         }
             
-        if (empty(config('responsecache.cache_tag')) {
+        if (empty(config('responsecache.cache_tag'))) {
             $this->cache->clear();
         }
 


### PR DESCRIPTION
@freekmurze , this should fix the breaking change introduced by #316.

The problem was not checking if we already had a cache tag before using the one from config.

Cheers.