### PR TITLE
Fix clearing cache when using tags

### DIFF
--- a/src/ResponseCacheRepository.php
+++ b/src/ResponseCacheRepository.php
@@ -42,7 +42,7 @@ class ResponseCacheRepository
 
     public function clear(): void
     {
-        if ($this->isTagged($this->cache)) {
+        if (!$this->isTagged($this->cache)) {
             $this->cache->clear();
 
             return;

--- a/src/ResponseCacheRepository.php
+++ b/src/ResponseCacheRepository.php
@@ -42,8 +42,8 @@ class ResponseCacheRepository
 
     public function clear(): void
     {
-        if (!$this->isTagged($this->cache)) {
-            $this->cache->clear();
+        if ($this->isTagged($this->cache)) {
+            $this->cache->flush();
 
             return;
         }


### PR DESCRIPTION
When using tags, laravel-responsecache should not be clearing all cache.