### PR TITLE
Possible for fix for #331

### DIFF
--- a/src/ResponseCacheRepository.php
+++ b/src/ResponseCacheRepository.php
@@ -43,7 +43,7 @@ class ResponseCacheRepository
     public function clear(): void
     {
         if ($this->isTagged($this->cache)) {
-            $this->cache->clear();
+            $this->cache->flush();
 
             return;
         }

--- a/tests/TaggingTest.php
+++ b/tests/TaggingTest.php
@@ -64,6 +64,24 @@ class TaggingTest extends TestCase
     }
 
     /** @test */
+    public function it_can_forget_requests_using_route_cache_tags_without_deleting_unrelated_cache()
+    {
+        $this->app['cache']->store(config('responsecache.cache_store'))->tags('unrelated-cache')->put('baz', true);
+
+        $firstResponse = $this->get('/tagged/1');
+        $this->assertRegularResponse($firstResponse);
+
+        $this->app['responsecache']->clear();
+
+        $secondResponse = $this->get('/tagged/1');
+        $this->assertRegularResponse($secondResponse);
+        $this->assertDifferentResponse($firstResponse, $secondResponse);
+
+        $cacheValue = $this->app['cache']->store(config('responsecache.cache_store'))->tags('unrelated-cache')->get('baz');
+        self::assertThat($cacheValue, self::isTrue(), 'Failed to assert that a cached value is present');
+    }
+
+    /** @test */
     public function it_can_forget_requests_using_multiple_route_cache_tags()
     {
         $firstResponse = $this->get('/tagged/2');


### PR DESCRIPTION
See the discussion in issue #331.

Currently, the following tests fail.
- `TaggingTest::it_can_forget_requests_using_route_cache_tags`
- `TaggingTest::it_can_forget_requests_using_route_cache_tags_without_deleting_unrelated_cache`
- `TaggingTest::it_can_forget_requests_using_multiple_route_cache_tags`

I am not sure why, but had no time to take a deeper look into this. The results of the unit test are the exact opposite of what I got with manual testing the cases in my application.