### PR TITLE
Add PHP 8-only Support (v7)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,3 @@
-; This file is for unifying the coding style for different editors and IDEs.
-; More information at http://editorconfig.org
-
 root = true
 
 [*]
@@ -13,3 +10,6 @@ trim_trailing_whitespace = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,10 +2,14 @@
 # https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
 
 # Ignore all test and documentation with "export-ignore".
+/.github            export-ignore
 /.gitattributes     export-ignore
 /.gitignore         export-ignore
-/.travis.yml        export-ignore
 /phpunit.xml.dist   export-ignore
-/.scrutinizer.yml   export-ignore
 /tests              export-ignore
+/.editorconfig      export-ignore
+/.php_cs.dist       export-ignore
+/psalm.xml          export-ignore
+/psalm.xml.dist     export-ignore
+/testbench.yaml     export-ignore
 /art                export-ignore

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,31 +2,54 @@
 
 Contributions are **welcome** and will be fully **credited**.
 
-We accept contributions via Pull Requests on [Github](https://github.com/thephpleague/laravel-responsecache).
+Please read and understand the contribution guide before creating an issue or pull request.
 
+## Etiquette
 
-## Pull Requests
+This project is open source, and as such, the maintainers give their free time to build and maintain the source code
+held within. They make the code freely available in the hope that it will be of use to other developers. It would be
+extremely unfair for them to suffer abuse or anger for their hard work.
 
-- **[PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)** - The easiest way to apply the conventions is to install [PHP Code Sniffer](http://pear.php.net/package/PHP_CodeSniffer).
+Please be considerate towards maintainers when raising issues or presenting pull requests. Let's show the
+world that developers are civilized and selfless people.
+
+It's the duty of the maintainer to ensure that all submissions to the project are of sufficient
+quality to benefit the project. Many developers have different skillsets, strengths, and weaknesses. Respect the maintainer's decision, and do not be upset or abusive if your submission is not used.
+
+## Viability
+
+When requesting or submitting new features, first consider whether it might be useful to others. Open
+source projects are used by many developers, who may have entirely different needs to your own. Think about
+whether or not your feature is likely to be used by other users of the project.
+
+## Procedure
+
+Before filing an issue:
+
+- Attempt to replicate the problem, to ensure that it wasn't a coincidental incident.
+- Check to make sure your feature suggestion isn't already present within the project.
+- Check the pull requests tab to ensure that the bug doesn't have a fix in progress.
+- Check the pull requests tab to ensure that the feature isn't already in progress.
+
+Before submitting a pull request:
+
+- Check the codebase to ensure that your feature doesn't already exist.
+- Check the pull requests to ensure that another person hasn't already submitted the feature or fix.
+
+## Requirements
+
+If the project maintainer has any additional requirements, you will find them listed here.
+
+- **[PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)** - The easiest way to apply the conventions is to install [PHP Code Sniffer](https://pear.php.net/package/PHP_CodeSniffer).
 
 - **Add tests!** - Your patch won't be accepted if it doesn't have tests.
 
 - **Document any change in behaviour** - Make sure the `README.md` and any other relevant documentation are kept up-to-date.
 
-- **Consider our release cycle** - We try to follow [SemVer v2.0.0](http://semver.org/). Randomly breaking public APIs is not an option.
-
-- **Create feature branches** - Don't ask us to pull from your master branch.
+- **Consider our release cycle** - We try to follow [SemVer v2.0.0](https://semver.org/). Randomly breaking public APIs is not an option.
 
 - **One pull request per feature** - If you want to do more than one thing, send multiple pull requests.
 
-- **Send coherent history** - Make sure each individual commit in your pull request is meaningful. If you had to make multiple intermediate commits while developing, please [squash them](http://www.git-scm.com/book/en/v2/Git-Tools-Rewriting-History#Changing-Multiple-Commit-Messages) before submitting.
-
-
-## Running Tests
-
-``` bash
-$ phpunit
-```
-
+- **Send coherent history** - Make sure each individual commit in your pull request is meaningful. If you had to make multiple intermediate commits while developing, please [squash them](https://www.git-scm.com/book/en/v2/Git-Tools-Rewriting-History#Changing-Multiple-Commit-Messages) before submitting.
 
 **Happy coding**!

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
+github: spatie
 custom: https://spatie.be/open-source/support-us

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -1,29 +1,29 @@
 name: Check & fix styling
 
-on: [push]
+on: [ push ]
 
 jobs:
-    style:
-        runs-on: ubuntu-latest
+  style:
+    runs-on: ubuntu-latest
 
-        steps:
-            -   name: Checkout code
-                uses: actions/checkout@v2
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
 
-            -   name: Fix style
-                uses: docker://oskarstark/php-cs-fixer-ga
-                with:
-                    args: --config=.php_cs --allow-risky=yes
+      - name: Fix style
+        uses: docker://oskarstark/php-cs-fixer-ga
+        with:
+          args: --config=.php_cs.dist --allow-risky=yes
 
-            -   name: Extract branch name
-                shell: bash
-                run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-                id: extract_branch
+      - name: Extract branch name
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
 
-            -   name: Commit changes
-                uses: stefanzweifel/git-auto-commit-action@v2.3.0
-                with:
-                    commit_message: Fix styling
-                    branch: ${{ steps.extract_branch.outputs.branch }}
-                env:
-                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v2.3.0
+        with:
+          commit_message: Fix styling
+          branch: ${{ steps.extract_branch.outputs.branch }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -1,0 +1,33 @@
+name: Psalm
+
+on:
+  push:
+    paths:
+      - '**.php'
+      - 'psalm.xml.dist'
+
+jobs:
+  psalm:
+    name: psalm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.0'
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
+          coverage: none
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v2
+        with:
+          path: vendor
+          key: composer-${{ hashFiles('composer.lock') }}
+
+      - name: Run composer install
+        run: composer install -n --prefer-dist
+
+      - name: Run psalm
+        run: ./vendor/bin/psalm --output-format=github

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,35 +4,46 @@ on:
   push:
   pull_request:
   schedule:
-      - cron: '0 0 * * *'
+    - cron: '0 0 * * *'
 
 jobs:
-    test:
+  test:
 
-        runs-on: ubuntu-latest
-        strategy:
-            fail-fast: true
-            matrix:
-                php: [8.0, 7.4]
-                laravel: [7.*, 8.*]
-                dependency-version: [prefer-lowest, prefer-stable]
-                include:
-                    - laravel: 8.*
-                      testbench: 6.*
-                    - laravel: 7.*
-                      testbench: 5.*
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        php: [ 8.0 ]
+        laravel: [ 7.*, 8.* ]
+        dependency-version: [ prefer-lowest, prefer-stable ]
+        include:
+          - laravel: 8.*
+            testbench: 6.*
+          - laravel: 7.*
+            testbench: 5.*
 
-        name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v2
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
 
-            - name: Install dependencies
-              run: |
-                  composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-                  composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
+          coverage: none
 
-            - name: Execute tests
-              run: vendor/bin/phpunit
+      - name: Setup problem matchers
+        run: |
+          echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+          echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
+      - name: Install dependencies
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+
+      - name: Execute tests
+        run: vendor/bin/phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,13 @@
+.idea
+.php_cs
+.php_cs.cache
+.phpunit.result.cache
 build
 composer.lock
+coverage
 docs
-vendor
+phpunit.xml
+psalm.xml
+testbench.yaml
 tests/temp
-.phpunit.result.cache
-.php_cs.cache
+vendor

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -3,7 +3,7 @@
 $finder = Symfony\Component\Finder\Finder::create()
     ->notPath('bootstrap/*')
     ->notPath('storage/*')
-    ->notPath('vendor')
+    ->notPath('resources/view/mail/*')
     ->in([
         __DIR__ . '/src',
         __DIR__ . '/tests',
@@ -31,12 +31,13 @@ return PhpCsFixer\Config::create()
         'phpdoc_var_without_name' => true,
         'class_attributes_separation' => [
             'elements' => [
-                'method', 'property',
+                'method',
             ],
         ],
         'method_argument_space' => [
             'on_multiline' => 'ensure_fully_multiline',
             'keep_multiple_spaces_after_comma' => true,
-        ]
+        ],
+        'single_trait_insert_per_statement' => true,
     ])
     ->setFinder($finder);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `laravel-responsecache` will be documented in this file.
 
+## 7.0.0 - unreleased
+
+- require PHP 8+
+- drop support for PHP 7.x
+- use PHP 8 syntax where possible
+
 ## 6.6.9 - 2021-03-30
 
 - fix for issue #331 (#344)

--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ We highly appreciate you sending us a postcard from your hometown, mentioning wh
 
 ## Installation
 
+> If you're using PHP 7, install v6.x of this package.
+
 You can install the package via composer:
-``` bash
+```bash
 composer require spatie/laravel-responsecache
 ```
 

--- a/README.md
+++ b/README.md
@@ -373,12 +373,12 @@ You can create your own replacers by implementing the `Spatie\ResponseCache\Repl
 interface Replacer
 {
     /*
-     * Transform the initial response before it gets cached.
+     * Prepare the initial response before it gets cached.
      *
      * For example: replace a generated csrf_token by '<csrf-token-here>' that you can
      * replace with its dynamic counterpart when the cached response is returned.
      */
-    public function transformInitialResponse(Response $response): void;
+    public function prepareResponseToCache(Response $response): void;
 
     /*
      * Replace any data you want in the cached response before it gets
@@ -386,7 +386,7 @@ interface Replacer
      *
      * For example: replace '<csrf-token-here>' by a call to csrf_token()
      */
-    public function replaceCachedResponse(Response $response): void;
+    public function replaceInCachedResponse(Response $response): void;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -422,11 +422,6 @@ interface Serializer
     public function unserialize(string $serializedResponse): Response;
 }
 ```
-
-## Changelog
-
-Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.
-
 ## Testing
 
 You can run the tests with:
@@ -439,9 +434,13 @@ composer test
 - [Barry Vd. Heuvel](https://twitter.com/barryvdh) made [a package that caches responses by leveraging HttpCache](https://github.com/barryvdh/laravel-httpcache).
 - [Joseph Silber](https://twitter.com/joseph_silber) created [Laravel Page Cache](https://github.com/JosephSilber/page-cache) that can write it's cache to disk and let Nginx read them, so PHP doesn't even have to start up anymore.
 
+## Changelog
+
+Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.
+
 ## Contributing
 
-Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
+Please see [CONTRIBUTING](.github/CONTRIBUTING.md) for details.
 
 ## Security
 

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
         "laravel/framework": "^7.13|^8.0",
         "phpunit/phpunit" : "^9.3",
         "orchestra/testbench": "^5.2|^6.0",
-        "mockery/mockery": "^1.4"
+        "mockery/mockery": "^1.4",
+        "vimeo/psalm": "^4.4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "illuminate/cache": "^7.13|^8.0",
         "illuminate/container": "^7.13|^8.0",
         "illuminate/console": "^7.13|^8.0",
@@ -31,7 +31,7 @@
     },
     "require-dev": {
         "laravel/framework": "^7.13|^8.0",
-        "phpunit/phpunit" : "^9.1.5",
+        "phpunit/phpunit" : "^9.3",
         "orchestra/testbench": "^5.2|^6.0",
         "mockery/mockery": "^1.4"
     },
@@ -48,6 +48,9 @@
     "scripts": {
         "psalm": "vendor/bin/psalm",
         "test": "vendor/bin/phpunit"
+    },
+    "config": {
+        "sort-packages": true
     },
     "extra": {
         "laravel": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
-  </coverage>
-  <testsuites>
-    <testsuite name="League Test Suite">
-      <directory>tests</directory>
-    </testsuite>
-  </testsuites>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    bootstrap="vendor/autoload.php"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    processIsolation="false"
+    stopOnFailure="false"
+    executionOrder="random"
+    failOnWarning="true"
+    failOnRisky="true"
+    failOnEmptyTestSuite="true"
+    beStrictAboutOutputDuringTests="true"
+    verbose="true"
+>
+    <testsuites>
+        <testsuite name="VendorName Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <coverage>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+        <report>
+            <html outputDirectory="build/coverage"/>
+            <text outputFile="build/coverage.txt"/>
+            <clover outputFile="build/logs/clover.xml"/>
+        </report>
+    </coverage>
+    <logging>
+        <junit outputFile="build/report.junit.xml"/>
+    </logging>
 </phpunit>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -3,7 +3,6 @@
     errorLevel="4"
     findUnusedVariablesAndParams="true"
     resolveFromConfigFile="true"
-    useDocblockPropertyTypes="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
@@ -14,7 +13,4 @@
             <directory name="vendor"/>
         </ignoreFiles>
     </projectFiles>
-
-    <issueHandlers>
-    </issueHandlers>
 </psalm>

--- a/src/CacheProfiles/CacheAllSuccessfulGetRequests.php
+++ b/src/CacheProfiles/CacheAllSuccessfulGetRequests.php
@@ -51,7 +51,7 @@ class CacheAllSuccessfulGetRequests extends BaseCacheProfile
     {
         $contentType = $response->headers->get('Content-Type', '');
 
-        if (Str::startsWith($contentType, 'text/')) {
+        if (str_starts_with($contentType, 'text/')) {
             return true;
         }
 

--- a/src/Events/CacheMissed.php
+++ b/src/Events/CacheMissed.php
@@ -6,10 +6,9 @@ use Illuminate\Http\Request;
 
 class CacheMissed
 {
-    public Request $request;
-
-    public function __construct(Request $request)
-    {
-        $this->request = $request;
+    public function __construct(
+        public Request $request,
+    ) {
+        //
     }
 }

--- a/src/Events/ResponseCacheHit.php
+++ b/src/Events/ResponseCacheHit.php
@@ -6,10 +6,9 @@ use Illuminate\Http\Request;
 
 class ResponseCacheHit
 {
-    public Request $request;
-
-    public function __construct(Request $request)
-    {
-        $this->request = $request;
+    public function __construct(
+        public Request $request,
+    ) {
+        //
     }
 }

--- a/src/Exceptions/CouldNotUnserialize.php
+++ b/src/Exceptions/CouldNotUnserialize.php
@@ -6,7 +6,7 @@ use Exception;
 
 class CouldNotUnserialize extends Exception
 {
-    public static function serializedResponse(string $serializedResponse): self
+    public static function serializedResponse(string $serializedResponse): static
     {
         return new static("Could not unserialize serialized response `{$serializedResponse}`");
     }

--- a/src/Hasher/DefaultHasher.php
+++ b/src/Hasher/DefaultHasher.php
@@ -7,11 +7,10 @@ use Spatie\ResponseCache\CacheProfiles\CacheProfile;
 
 class DefaultHasher implements RequestHasher
 {
-    protected CacheProfile $cacheProfile;
-
-    public function __construct(CacheProfile $cacheProfile)
-    {
-        $this->cacheProfile = $cacheProfile;
+    public function __construct(
+        protected CacheProfile $cacheProfile,
+    ) {
+        //
     }
 
     public function getHashFor(Request $request): string

--- a/src/Middlewares/CacheResponse.php
+++ b/src/Middlewares/CacheResponse.php
@@ -60,9 +60,7 @@ class CacheResponse
     ): void {
         $cachedResponse = clone $response;
 
-        $this->getReplacers()->each(function (Replacer $replacer) use ($cachedResponse) {
-            $replacer->prepareResponseToCache($cachedResponse);
-        });
+        $this->getReplacers()->each(fn (Replacer $replacer) => $replacer->prepareResponseToCache($cachedResponse));
 
         $this->responseCache->cacheResponse($request, $cachedResponse, $lifetimeInSeconds, $tags);
     }
@@ -70,9 +68,7 @@ class CacheResponse
     protected function getReplacers(): Collection
     {
         return collect(config('responsecache.replacers'))
-            ->map(function (string $replacerClass) {
-                return app($replacerClass);
-            });
+            ->map(fn (string $replacerClass) => app($replacerClass));
     }
 
     protected function getLifetime(array $args): ?int

--- a/src/ResponseCache.php
+++ b/src/ResponseCache.php
@@ -10,17 +10,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ResponseCache
 {
-    protected ResponseCacheRepository $cache;
-
-    protected RequestHasher $hasher;
-
-    protected CacheProfile $cacheProfile;
-
-    public function __construct(ResponseCacheRepository $cache, RequestHasher $hasher, CacheProfile $cacheProfile)
-    {
-        $this->cache = $cache;
-        $this->hasher = $hasher;
-        $this->cacheProfile = $cacheProfile;
+    public function __construct(
+        protected ResponseCacheRepository $cache,
+        protected RequestHasher $hasher,
+        protected CacheProfile $cacheProfile,
+    ) {
+        //
     }
 
     public function enabled(Request $request): bool
@@ -72,7 +67,7 @@ class ResponseCache
         return $this->taggedCache($tags)->get($this->hasher->getHashFor($request));
     }
 
-    public function clear(array $tags = [])
+    public function clear(array $tags = []): void
     {
         $this->taggedCache($tags)->clear();
     }
@@ -89,13 +84,7 @@ class ResponseCache
         return $clonedResponse;
     }
 
-    /**
-     * @param string|array $uris
-     * @param string[]        $tags
-     *
-     * @return \Spatie\ResponseCache\ResponseCache
-     */
-    public function forget($uris, array $tags = []): self
+    public function forget(string | array $uris, array $tags = []): self
     {
         $uris = is_array($uris) ? $uris : func_get_args();
 

--- a/src/ResponseCacheRepository.php
+++ b/src/ResponseCacheRepository.php
@@ -16,12 +16,7 @@ class ResponseCacheRepository
         //
     }
 
-    /**
-     * @param string $key
-     * @param \Symfony\Component\HttpFoundation\Response $response
-     * @param \DateTime|int $seconds
-     */
-    public function put(string $key, $response, \DateTime | int $seconds): void
+    public function put(string $key, Response $response, \DateTime | int $seconds): void
     {
         $this->cache->put($key, $this->responseSerializer->serialize($response), is_numeric($seconds) ? now()->addSeconds($seconds) : $seconds);
     }

--- a/src/ResponseCacheRepository.php
+++ b/src/ResponseCacheRepository.php
@@ -9,15 +9,11 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ResponseCacheRepository
 {
-    protected Repository $cache;
-
-    protected Serializer $responseSerializer;
-
-    public function __construct(Serializer $responseSerializer, Repository $cache)
-    {
-        $this->cache = $cache;
-
-        $this->responseSerializer = $responseSerializer;
+    public function __construct(
+        protected Serializer $responseSerializer,
+        protected Repository $cache,
+    ) {
+        //
     }
 
     /**
@@ -25,7 +21,7 @@ class ResponseCacheRepository
      * @param \Symfony\Component\HttpFoundation\Response $response
      * @param \DateTime|int $seconds
      */
-    public function put(string $key, $response, $seconds)
+    public function put(string $key, $response, \DateTime | int $seconds): void
     {
         $this->cache->put($key, $this->responseSerializer->serialize($response), is_numeric($seconds) ? now()->addSeconds($seconds) : $seconds);
     }


### PR DESCRIPTION
This PR adds a new major version, v7.0.0.

Specifically, it:

- Removes support for all PHP 7.x versions.
- Requires PHP 8.0+.
- Uses PHP 8 syntax where possible.
- Removes unnecessary PHP docblocks per Spatie's guidelines.
- Adds `vimeo/psalm` & github workflow.
- Adds/updates several files to more closely match `spatie/package-skeleton-laravel`.
- Adds a note on what package version to use for PHP 7 to the readme.
- _Updates the changelog - release date needs to be updated, currently is "unreleased"._