### PR TITLE
Make console command work with url option

### DIFF
--- a/src/Commands/ClearCommand.php
+++ b/src/Commands/ClearCommand.php
@@ -9,7 +9,7 @@ use Spatie\ResponseCache\ResponseCacheRepository;
 
 class ClearCommand extends Command
 {
-    protected $signature = 'responsecache:clear';
+    protected $signature = 'responsecache:clear {--url=}';
 
     protected $description = 'Clear the response cache';
 
@@ -17,7 +17,11 @@ class ClearCommand extends Command
     {
         event(new ClearingResponseCache());
 
-        $cache->clear();
+        if ($url = $this->option('url')) {
+            $cache->forget($url);
+        } else {
+            $this->clear($cache);
+        }
 
         event(new ClearedResponseCache());
 

--- a/src/Commands/ClearCommand.php
+++ b/src/Commands/ClearCommand.php
@@ -4,7 +4,6 @@ namespace Spatie\ResponseCache\Commands;
 
 use Illuminate\Console\Command;
 use Spatie\ResponseCache\Facades\ResponseCache;
-use Spatie\ResponseCache\ResponseCacheRepository;
 use Spatie\ResponseCache\Events\ClearedResponseCache;
 use Spatie\ResponseCache\Events\ClearingResponseCache;
 
@@ -14,18 +13,23 @@ class ClearCommand extends Command
 
     protected $description = 'Clear the response cache';
 
-    public function handle(ResponseCacheRepository $cache)
+    public function handle()
     {
         event(new ClearingResponseCache());
 
-        if ($url = $this->option('url')) {
-            ResponseCache::forget($url);
-        } else {
-            $cache->clear();
-        }
+        $this->clear();
 
         event(new ClearedResponseCache());
 
         $this->info('Response cache cleared!');
+    }
+
+    protected function clear()
+    {
+        if ($url = $this->option('url')) {
+            return ResponseCache::forget($url);
+        }
+
+        ResponseCache::clear();
     }
 }

--- a/src/Commands/ClearCommand.php
+++ b/src/Commands/ClearCommand.php
@@ -3,9 +3,10 @@
 namespace Spatie\ResponseCache\Commands;
 
 use Illuminate\Console\Command;
+use Spatie\ResponseCache\Facades\ResponseCache;
+use Spatie\ResponseCache\ResponseCacheRepository;
 use Spatie\ResponseCache\Events\ClearedResponseCache;
 use Spatie\ResponseCache\Events\ClearingResponseCache;
-use Spatie\ResponseCache\ResponseCacheRepository;
 
 class ClearCommand extends Command
 {
@@ -18,9 +19,9 @@ class ClearCommand extends Command
         event(new ClearingResponseCache());
 
         if ($url = $this->option('url')) {
-            $cache->forget($url);
+            ResponseCache::forget($url);
         } else {
-            $this->clear($cache);
+            $cache->clear();
         }
 
         event(new ClearedResponseCache());

--- a/tests/Commands/ClearCommandTest.php
+++ b/tests/Commands/ClearCommandTest.php
@@ -30,12 +30,12 @@ class ClearCommandTest extends TestCase
     /** @test */
     public function it_will_clear_only_one_page_from_cache()
     {
-        $firstResponse            = $this->get('/random/1');
+        $firstResponse = $this->get('/random/1');
         $firstAlternativeResponse = $this->get('/random/2');
 
         Artisan::call('responsecache:clear --url=/random/1');
 
-        $secondResponse            = $this->get('/random/1');
+        $secondResponse = $this->get('/random/1');
         $secondAlternativeResponse = $this->get('/random/2');
 
         $this->assertRegularResponse($firstResponse);

--- a/tests/Commands/ClearCommandTest.php
+++ b/tests/Commands/ClearCommandTest.php
@@ -28,6 +28,26 @@ class ClearCommandTest extends TestCase
     }
 
     /** @test */
+    public function it_will_clear_only_one_page_from_cache()
+    {
+        $firstResponse            = $this->get('/random/1');
+        $firstAlternativeResponse = $this->get('/random/2');
+
+        Artisan::call('responsecache:clear --url=/random/1');
+
+        $secondResponse            = $this->get('/random/1');
+        $secondAlternativeResponse = $this->get('/random/2');
+
+        $this->assertRegularResponse($firstResponse);
+        $this->assertRegularResponse($secondResponse);
+        $this->assertDifferentResponse($firstResponse, $secondResponse);
+
+        $this->assertRegularResponse($firstAlternativeResponse);
+        $this->assertCachedResponse($secondAlternativeResponse);
+        $this->assertSameResponse($firstAlternativeResponse, $secondAlternativeResponse);
+    }
+
+    /** @test */
     public function it_will_fire_events_when_clearing_the_cache()
     {
         Event::fake();


### PR DESCRIPTION
To make the console command work for one specific URL this option is added. Now this package combined with laravel-remote becomes even more powerful!