### PR TITLE
Added Cache Cleaner

### DIFF
--- a/src/CacheCleaner.php
+++ b/src/CacheCleaner.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Spatie\ResponseCache;
+
+use Illuminate\Http\Request;
+use Spatie\ResponseCache\Hasher\RequestHasher;
+use Illuminate\Support\Str;
+
+class CacheCleaner
+{
+    protected string $method = 'GET';
+    protected array $parameters = [];
+    protected array $cookies = [];
+    protected array $server = [];
+
+    public function __construct(
+        protected RequestHasher $hasher,
+        protected ResponseCacheRepository $cache,
+    ) {
+    }
+
+    /**
+     * Set the value of method
+     *
+     * @return  self
+     */
+    public function setMethod(string $method)
+    {
+        $this->method = strtoupper($method);
+
+        return $this;
+    }
+
+    /**
+     * Set parameters value
+     * if method is GET then will be converted to query
+     * otherwise it will became part of request input
+     * @return  self
+     */
+    public function setParameters(array $parameters)
+    {
+        $this->parameters = $parameters;
+
+        return $this;
+    }
+
+    /**
+     * Set the value of cookies
+     *
+     * @return  self
+     */
+    public function setCookies(array $cookies)
+    {
+        $this->cookies = $cookies;
+
+        return $this;
+    }
+
+    /**
+     * Set the value of headers
+     *
+     * @return  self
+     */
+    public function setHeaders(array $headers)
+    {
+        $this->server = collect($this->server)
+            ->filter(function (string $val, string $key) {
+                return !Str::startsWith($key, 'HTTP_');
+            })->merge(collect($headers)
+                ->mapWithKeys(function (string $val, string $key) {
+                    return ['HTTP_' . str_replace('-', '_', Str::upper($key)) => $val];
+                }))
+            ->toArray();
+
+        return $this;
+    }
+
+    /**
+     * Set the value of remoteAddress
+     *
+     * @return  self
+     */
+    public function setRemoteAddress($remoteAddress)
+    {
+        $this->server['REMOTE_ADDR'] = $remoteAddress;
+        return $this;
+    }
+
+
+    /**
+     * @return void
+     */
+    public function forget(string | array $uris,  $tags = [])
+    {
+        if (!is_array($uris)) {
+            $uris = [$uris];
+        }
+
+        $cache = $this->cache;
+        if (!empty($tags)) {
+            $cache = $cache->tags($tags);
+        }
+
+        collect($uris)->map(function ($uri) {
+            $request = Request::create($uri, $this->method, $this->parameters, $this->cookies, [], $this->server);
+            $hash = $this->hasher->getHashFor($request);
+            return $hash;
+        })->each(function ($hash) use ($cache) {
+            if ($cache->has($hash)) {
+                $cache->forget($hash);
+            }
+        });
+    }
+}

--- a/src/ResponseCache.php
+++ b/src/ResponseCache.php
@@ -29,7 +29,7 @@ class ResponseCache
             return false;
         }
 
-        if (! $this->cacheProfile->shouldCacheRequest($request)) {
+        if (!$this->cacheProfile->shouldCacheRequest($request)) {
             return false;
         }
 
@@ -84,6 +84,7 @@ class ResponseCache
         return $clonedResponse;
     }
 
+    /** @deprecated use cacheCleaner() instead */
     public function forget(string | array $uris, array $tags = []): self
     {
         $uris = is_array($uris) ? $uris : func_get_args();
@@ -98,6 +99,11 @@ class ResponseCache
         });
 
         return $this;
+    }
+
+    public function cacheCleaner(): CacheCleaner
+    {
+        return new CacheCleaner($this->hasher, $this->cache);
     }
 
     protected function taggedCache(array $tags = []): ResponseCacheRepository


### PR DESCRIPTION
ResponseCache::forget() lacks of control of many request fields,
and only supports GET method.
The CacheCleaner Object give more control.

ResponseCache::forget() should be deprecated