### PR TITLE
Added CacheCleaner to give more control when clearing the cache

### DIFF
--- a/src/CacheCleaner.php
+++ b/src/CacheCleaner.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Spatie\ResponseCache;
+
+use Illuminate\Http\Request;
+use Spatie\ResponseCache\Hasher\RequestHasher;
+use Illuminate\Support\Str;
+
+class CacheCleaner
+{
+    protected string $method = 'GET';
+    protected array $parameters = [];
+    protected array $cookies = [];
+    protected array $server = [];
+
+    public function __construct(
+        protected RequestHasher $hasher,
+        protected ResponseCacheRepository $cache,
+    ) {
+    }
+
+    /**
+     * Set the value of method
+     *
+     * @return  self
+     */
+    public function setMethod(string $method)
+    {
+        $this->method = strtoupper($method);
+
+        return $this;
+    }
+
+    /**
+     * Set parameters value
+     * if method is GET then will be converted to query
+     * otherwise it will became part of request input
+     * @return  self
+     */
+    public function setParameters(array $parameters)
+    {
+        $this->parameters = $parameters;
+
+        return $this;
+    }
+
+    /**
+     * Set the value of cookies
+     *
+     * @return  self
+     */
+    public function setCookies(array $cookies)
+    {
+        $this->cookies = $cookies;
+
+        return $this;
+    }
+
+    /**
+     * Set the value of headers
+     *
+     * @return  self
+     */
+    public function setHeaders(array $headers)
+    {
+        $this->server = collect($this->server)
+            ->filter(function (string $val, string $key) {
+                return !Str::startsWith($key, 'HTTP_');
+            })->merge(collect($headers)
+                ->mapWithKeys(function (string $val, string $key) {
+                    return ['HTTP_' . str_replace('-', '_', Str::upper($key)) => $val];
+                }))
+            ->toArray();
+
+        return $this;
+    }
+
+    /**
+     * Set the value of remoteAddress
+     *
+     * @return  self
+     */
+    public function setRemoteAddress($remoteAddress)
+    {
+        $this->server['REMOTE_ADDR'] = $remoteAddress;
+        return $this;
+    }
+
+
+    /**
+     * @return void
+     */
+    public function forget(string | array $uris,  $tags = [])
+    {
+        if (!is_array($uris)) {
+            $uris = [$uris];
+        }
+
+        $cache = $this->cache;
+        if (!empty($tags)) {
+            $cache = $cache->tags($tags);
+        }
+
+        collect($uris)->map(function ($uri) {
+            $request = Request::create($uri, $this->method, $this->parameters, $this->cookies, [], $this->server);
+            $hash = $this->hasher->getHashFor($request);
+            return $hash;
+        })->each(function ($hash) use ($cache) {
+            if ($cache->has($hash)) {
+                $cache->forget($hash);
+            }
+        });
+    }
+}

--- a/src/CacheCleaner/CacheCleaner.php
+++ b/src/CacheCleaner/CacheCleaner.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Spatie\ResponseCache\CacheCleaner;
+
+use Illuminate\Http\Request;
+use Spatie\ResponseCache\Hasher\RequestHasher;
+use Spatie\ResponseCache\ResponseCacheRepository;
+
+class CacheCleaner extends AbstractRequestBuilder
+{
+    public function __construct(
+        protected RequestHasher $hasher,
+        protected ResponseCacheRepository $cache,
+    ) {
+    }
+
+    /**
+     * @return void
+     */
+    public function forget(string | array $uris,  $tags = [])
+    {
+        if (!is_array($uris)) {
+            $uris = [$uris];
+        }
+
+        $cache = $this->cache;
+        if (!empty($tags)) {
+            $cache = $cache->tags($tags);
+        }
+
+        collect($uris)->map(function ($uri) {
+            $request = $this->_build($uri);
+            $hash = $this->hasher->getHashFor($request);
+            return $hash;
+        })->each(function ($hash) use ($cache) {
+            if ($cache->has($hash)) {
+                $cache->forget($hash);
+            }
+        });
+    }
+
+}

--- a/src/CacheCleaner/RequestBuilder.php
+++ b/src/CacheCleaner/RequestBuilder.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\ResponseCache\CacheCleaner;
+
+use Illuminate\Http\Request;
+
+class RequestBuilder extends AbstractRequestBuilder
+{
+    /**
+     * @return Request
+     */
+    public function build(string $uri): Request
+    {
+        return $this->_build($uri);
+    }
+}

--- a/src/ResponseCache.php
+++ b/src/ResponseCache.php
@@ -29,7 +29,7 @@ class ResponseCache
             return false;
         }
 
-        if (! $this->cacheProfile->shouldCacheRequest($request)) {
+        if (!$this->cacheProfile->shouldCacheRequest($request)) {
             return false;
         }
 
@@ -84,6 +84,7 @@ class ResponseCache
         return $clonedResponse;
     }
 
+    /** @deprecated use cacheCleaner() instead */
     public function forget(string | array $uris, array $tags = []): self
     {
         $uris = is_array($uris) ? $uris : func_get_args();
@@ -98,6 +99,11 @@ class ResponseCache
         });
 
         return $this;
+    }
+
+    public function cacheCleaner(): CacheCleaner
+    {
+        return new CacheCleaner($this->hasher, $this->cache);
     }
 
     protected function taggedCache(array $tags = []): ResponseCacheRepository

--- a/src/ResponseCache.php
+++ b/src/ResponseCache.php
@@ -4,6 +4,7 @@ namespace Spatie\ResponseCache;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
+use Spatie\ResponseCache\CacheCleaner\CacheCleaner;
 use Spatie\ResponseCache\CacheProfiles\CacheProfile;
 use Spatie\ResponseCache\Hasher\RequestHasher;
 use Symfony\Component\HttpFoundation\Response;

--- a/tests/CacheCleanerIntegrationTest.php
+++ b/tests/CacheCleanerIntegrationTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Spatie\ResponseCache\Test;
+
+use ResponseCache;
+use Spatie\ResponseCache\CacheProfiles\CacheAllSuccessfulGetRequests;
+use Illuminate\Http\Request;
+
+class CacheCleanerIntegrationTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set(
+            'responsecache.cache_profile',
+            CacheSuccessfulGetAndPostRequests::class // declared at the ends of this file
+        );
+    }
+
+    /** @test */
+    public function it_will_cache_a_post_request()
+    {
+        $firstResponse = $this->call('POST', '/random');
+        $secondResponse = $this->call('POST', '/random');
+
+        $this->assertRegularResponse($firstResponse);
+        $this->assertCachedResponse($secondResponse);
+
+        $this->assertSameResponse($firstResponse, $secondResponse);
+    }
+
+    /** @test */
+    public function it_can_forget_a_specific_cached_request_using_cache_cleaner()
+    {
+        config()->set('app.url', 'http://spatie.be');
+
+        $firstResponse = $this->get('/random?foo=bar');
+        $this->assertRegularResponse($firstResponse);
+
+        ResponseCache::cacheCleaner()->setParameters(['foo' => 'bar'])->forget('/random');
+
+        $secondResponse = $this->get('/random?foo=bar');
+        $this->assertRegularResponse($secondResponse);
+
+        $this->assertDifferentResponse($firstResponse, $secondResponse);
+    }
+    /** @test */
+    public function it_can_forget_a_specific_cached_request_using_cache_cleaner_post()
+    {
+        config()->set('app.url', 'http://spatie.be');
+
+        $firstResponse = $this->post('/random');
+        $this->assertRegularResponse($firstResponse);
+
+        ResponseCache::cacheCleaner()->setMethod('POST')->forget('/random');
+
+        $secondResponse = $this->post('/random');
+        $this->assertRegularResponse($secondResponse);
+
+        $this->assertDifferentResponse($firstResponse, $secondResponse);
+    }
+
+    /** @test */
+    public function it_can_forget_several_specific_cached_requests_at_once_using_cache_cleaner()
+    {
+        $firstResponseFirstCall = $this->get('/random/1?foo=bar');
+        $this->assertRegularResponse($firstResponseFirstCall);
+
+        $secondResponseFirstCall = $this->get('/random/2?foo=bar');
+        $this->assertRegularResponse($secondResponseFirstCall);
+
+        ResponseCache::cacheCleaner()->setParameters(['foo' => 'bar'])
+            ->forget(['/random/1', '/random/2']);
+
+        $firstResponseSecondCall = $this->get('/random/1?foo=bar');
+        $this->assertRegularResponse($firstResponseSecondCall);
+
+        $secondResponseSecondCall = $this->get('/random/2?foo=bar');
+        $this->assertRegularResponse($secondResponseSecondCall);
+
+        $this->assertDifferentResponse($firstResponseFirstCall, $firstResponseSecondCall);
+        $this->assertDifferentResponse($secondResponseFirstCall, $secondResponseSecondCall);
+    }
+    /** @test */
+    public function it_can_forget_several_specific_cached_requests_at_once_using_cache_cleaner_post()
+    {
+        $firstResponseFirstCall = $this->post('/random/1');
+        $this->assertRegularResponse($firstResponseFirstCall);
+
+        $secondResponseFirstCall = $this->post('/random/2');
+        $this->assertRegularResponse($secondResponseFirstCall);
+
+        ResponseCache::cacheCleaner()->setMethod('POST')->forget(['/random/1', '/random/2']);
+
+        $firstResponseSecondCall = $this->post('/random/1');
+        $this->assertRegularResponse($firstResponseSecondCall);
+
+        $secondResponseSecondCall = $this->post('/random/2');
+        $this->assertRegularResponse($secondResponseSecondCall);
+
+        $this->assertDifferentResponse($firstResponseFirstCall, $firstResponseSecondCall);
+        $this->assertDifferentResponse($secondResponseFirstCall, $secondResponseSecondCall);
+    }
+}
+
+
+class CacheSuccessfulGetAndPostRequests extends CacheAllSuccessfulGetRequests
+{
+    public function shouldCacheRequest(Request $request): bool
+    {
+        if ($request->ajax()) {
+            return false;
+        }
+        if ($this->isRunningInConsole()) {
+            return false;
+        }
+        return $request->isMethod('get') || $request->isMethod('post');
+    }
+}

--- a/tests/RequestBuilderTest.php
+++ b/tests/RequestBuilderTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Spatie\ResponseCache\Test;
+
+use Spatie\ResponseCache\CacheCleaner\RequestBuilder;
+
+class RequestBuilderTest extends TestCase
+{
+
+    /** @test */
+    public function request_builder_works()
+    {
+        $uri = '/foo';
+        $cookies = [
+            'cookie1' => 'cookie1_value',
+            'cookie2' => 'cookie2_value',
+        ];
+        $headers = [
+            'Header1' => 'Header1_value',
+            'Header2' => 'Header2_value',
+        ];
+        $parameters = [
+            'Param1' => 'Param1_value',
+            'Param2' => 'Param2_value',
+        ];
+
+        $request = (new RequestBuilder)
+            ->setParameters($parameters)
+            ->setHeaders($headers)
+            ->setCookies($cookies)
+            ->setRemoteAddress('127.0.1.1')
+            ->build($uri);
+
+        foreach ($parameters as $key => $value) {
+            $this->assertEquals($request->query($key), $value);
+        }
+        foreach ($headers as $key => $value) {
+            $this->assertEquals($request->header($key), $value);
+        }
+        foreach ($cookies as $key => $value) {
+            $this->assertEquals($request->cookie($key), $value);
+        }
+        $this->assertEquals($request->getRequestUri(), $uri . '?' . http_build_query($parameters));
+        $this->assertEquals($request->getMethod(), 'GET');
+        $this->assertEquals($request->ip(), '127.0.1.1');
+
+
+        $request = (new RequestBuilder)
+            ->setMethod('POST')
+            ->setParameters($parameters)
+            ->setHeaders($headers)
+            ->setCookies($cookies)
+            ->setRemoteAddress('127.0.1.1')
+            ->build($uri);
+
+        foreach ($parameters as $key => $value) {
+            $this->assertEquals($request->input($key), $value);
+        }
+        foreach ($headers as $key => $value) {
+            $this->assertEquals($request->header($key), $value);
+        }
+        foreach ($cookies as $key => $value) {
+            $this->assertEquals($request->cookie($key), $value);
+        }
+        $this->assertEquals($request->getRequestUri(), $uri);
+        $this->assertEquals($request->getMethod(), 'POST');
+        $this->assertEquals($request->ip(), '127.0.1.1');
+    }
+}


### PR DESCRIPTION
ResponseCache::forget() lacks of control of many request fields,
and only supports GET method.
The CacheCleaner Object give more control:

```
ResponseCache::cacheCleaner()
->setMethod('PUT')
->setHeaders(['foo'=>'bar'])
...
->forget('/foo',['tag1','tag2']);
```


I also added a deprecated note to ResponseCache::forget() since is no more necessary, but i want to avoid a breaking change.