### PR TITLE
Handle missed cache gracefully

### DIFF
--- a/src/ResponseCacheRepository.php
+++ b/src/ResponseCacheRepository.php
@@ -28,7 +28,7 @@ class ResponseCacheRepository
 
     public function get(string $key): Response
     {
-        return $this->responseSerializer->unserialize($this->cache->get($key));
+        return $this->responseSerializer->unserialize($this->cache->get($key) ?? '');
     }
 
     public function clear(): void

--- a/tests/ResponseCacheRepositoryTest.php
+++ b/tests/ResponseCacheRepositoryTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Spatie\ResponseCache\Test;
+
+use Illuminate\Cache\Repository;
+use Mockery;
+use Spatie\ResponseCache\Exceptions\CouldNotUnserialize;
+use Spatie\ResponseCache\ResponseCacheRepository;
+use Spatie\ResponseCache\Serializers\Serializer;
+
+class ResponseCacheRepositoryTest extends TestCase
+{
+    /** @test */
+    public function it_handles_missed_cache_gracefully()
+    {
+        // Instantiate a default serializer
+        $responseSerializer = app(Serializer::class);
+
+        $cacheRepository = Mockery::mock(Repository::class);
+        $cacheRepository->shouldReceive('get')->with('missed-cache')->once()->andReturn(null);
+
+        $this->expectException(CouldNotUnserialize::class);
+
+        $repository = new ResponseCacheRepository($responseSerializer, $cacheRepository);
+        $repository->get('missed-cache');
+    }
+}


### PR DESCRIPTION
Currently when the cache is missed for any reason and `$this->cache->get()` returns null it results is an error:

```Spatie\\ResponseCache\\Serializers\\DefaultSerializer::unserialize(): Argument #1 ($serializedResponse) must be of type string, null given, called in /vendor/spatie/laravel-responsecache/src/ResponseCacheRepository.php on line 31```

Since null cannot be unserialised, it would be better to account for that fact and throw `CouldNotUnserialize` exception giving the developers an opportunity to handle the exception in their code.