### PR TITLE
Add option to output cache age header

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,20 @@ return [
     'cache_time_header_name' => env('RESPONSE_CACHE_HEADER_NAME', 'laravel-responsecache'),
 
     /*
+     * This setting determines if a http header named with the cache age
+     * should be added to a cached response. This can be handy when
+     * debugging.
+     * ONLY works when "add_cache_time_header" is also active!
+     */
+    'add_cache_age_header' => env('RESPONSE_CACHE_AGE_HEADER', false),
+
+    /*
+     * This setting determines the name of the http header that contains
+     * the age of cache
+     */
+    'cache_age_header_name' => env('RESPONSE_CACHE_AGE_HEADER_NAME', 'laravel-responsecache-age'),
+
+    /*
      * Here you may define the cache store that should be used to store
      * requests. This can be the name of any store that is
      * configured in app/config/cache.php
@@ -105,15 +119,14 @@ return [
 
     /*
      * This class is responsible for generating a hash for a request. This hash
-     * is used as a key to look up a cached response.
+     * is used to look up an cached response.
      */
     'hasher' => \Spatie\ResponseCache\Hasher\DefaultHasher::class,
 
     /*
-     * This class serializes cache data and expands it.
-     * Serialization can save the data to be returned in an appropriate form.
+     * This class is responsible for serializing responses.
      */
-    'serializer' => \Spatie\ResponseCache\Serializer\DefaultSerializer::class,
+    'serializer' => \Spatie\ResponseCache\Serializers\DefaultSerializer::class,
 ];
 ```
 

--- a/config/responsecache.php
+++ b/config/responsecache.php
@@ -35,6 +35,20 @@ return [
     'cache_time_header_name' => env('RESPONSE_CACHE_HEADER_NAME', 'laravel-responsecache'),
 
     /*
+     * This setting determines if a http header named with the cache age
+     * should be added to a cached response. This can be handy when
+     * debugging.
+     * ONLY works when "add_cache_time_header" is also active!
+     */
+    'add_cache_age_header' => env('APP_DEBUG', false),
+
+    /*
+     * This setting determines the name of the http header that contains
+     * the age of cache
+     */
+    'cache_age_header_name' => env('RESPONSE_CACHE_AGE_HEADER_NAME', 'laravel-responsecache-age'),
+
+    /*
      * Here you may define the cache store that should be used to store
      * requests. This can be the name of any store that is
      * configured in app/config/cache.php

--- a/config/responsecache.php
+++ b/config/responsecache.php
@@ -40,7 +40,7 @@ return [
      * debugging.
      * ONLY works when "add_cache_time_header" is also active!
      */
-    'add_cache_age_header' => env('APP_DEBUG', false),
+    'add_cache_age_header' => env('RESPONSE_CACHE_AGE_HEADER', false),
 
     /*
      * This setting determines the name of the http header that contains

--- a/src/Middlewares/CacheResponse.php
+++ b/src/Middlewares/CacheResponse.php
@@ -32,11 +32,7 @@ class CacheResponse
 
                 $response = $this->responseCache->getCachedResponseFor($request, $tags);
 
-                // Add cache age header
-                if (config('responsecache.add_cache_age_header') and $time = $response->headers->get(config('responsecache.cache_time_header_name'))) {
-                    $ageInSeconds = Carbon::parse($time)->diffInSeconds(Carbon::now());
-                    $response->headers->set(config('responsecache.cache_age_header_name'), $ageInSeconds);
-                }
+                $response = $this->addCacheAgeHeader($response);
 
                 $this->getReplacers()->each(function (Replacer $replacer) use ($response) {
                     $replacer->replaceInCachedResponse($response);
@@ -96,5 +92,16 @@ class CacheResponse
         }
 
         return array_filter($tags);
+    }
+
+    public function addCacheAgeHeader(Response $response): Response
+    {
+        if (config('responsecache.add_cache_age_header') and $time = $response->headers->get(config('responsecache.cache_time_header_name'))) {
+            $ageInSeconds = Carbon::parse($time)->diffInSeconds(Carbon::now());
+
+            $response->headers->set(config('responsecache.cache_age_header_name'), $ageInSeconds);
+        }
+
+        return $response;
     }
 }

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -257,4 +257,22 @@ class IntegrationTest extends TestCase
 
         $this->assertSameResponse($firstResponse, $secondResponse);
     }
+
+    /** @test */
+    public function it_can_add_a_cache_age_header()
+    {
+        $this->app['config']->set('responsecache.add_cache_time_header', true);
+        $this->app['config']->set('responsecache.add_cache_age_header', true);
+        $this->app['config']->set('responsecache.cache_age_header_name', 'X-Cached-Age');
+
+        $firstResponse = $this->get('/random');
+        $secondResponse = $this->get('/random');
+
+        $this->assertFalse($firstResponse->headers->has('X-Cached-Age'));
+        $this->assertTrue($secondResponse->headers->has('X-Cached-Age'));
+
+        $this->assertIsNumeric($secondResponse->headers->get('X-Cached-Age'));
+
+        $this->assertSameResponse($firstResponse, $secondResponse);
+    }
 }


### PR DESCRIPTION
I find it handy to have an cache age header in my responses. This option is disabled by default, and only works when the time-header is also active