### PR TITLE
allow the cache ttl to be defined from the response expires header

### DIFF
--- a/src/CacheProfiles/BaseCacheProfile.php
+++ b/src/CacheProfiles/BaseCacheProfile.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use DateTime;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
 
 abstract class BaseCacheProfile implements CacheProfile
 {
@@ -14,11 +15,15 @@ abstract class BaseCacheProfile implements CacheProfile
         return config('responsecache.enabled');
     }
 
-    public function cacheRequestUntil(Request $request): DateTime
+    public function cacheRequestUntil(Request $request, Response $response): DateTime
     {
-        return Carbon::now()->addSeconds(
-            config('responsecache.cache_lifetime_in_seconds')
-        );
+        $ttl = config('responsecache.cache_lifetime_in_seconds');
+
+        if ($expiry = $response->getExpires()) {
+            $ttl = Carbon::now()->diffInSeconds($expiry);
+        }
+
+        return Carbon::now()->addSeconds($ttl);
     }
 
     public function useCacheNameSuffix(Request $request): string

--- a/src/CacheProfiles/CacheProfile.php
+++ b/src/CacheProfiles/CacheProfile.php
@@ -14,7 +14,7 @@ interface CacheProfile
 
     public function shouldCacheResponse(Response $response): bool;
 
-    public function cacheRequestUntil(Request $request): DateTime;
+    public function cacheRequestUntil(Request $request, Response $response): DateTime;
 
     /*
      * Return a string to differentiate this request from others.

--- a/src/ResponseCache.php
+++ b/src/ResponseCache.php
@@ -50,7 +50,7 @@ class ResponseCache
         $this->taggedCache($tags)->put(
             $this->hasher->getHashFor($request),
             $response,
-            $lifetimeInSeconds ?? $this->cacheProfile->cacheRequestUntil($request),
+            $lifetimeInSeconds ?? $this->cacheProfile->cacheRequestUntil($request, $response),
         );
 
         return $response;

--- a/tests/CacheProfiles/CacheAllSuccessfulGetRequestsTest.php
+++ b/tests/CacheProfiles/CacheAllSuccessfulGetRequestsTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\ResponseCache\Test\CacheProfiles;
 
+use DateTime;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Spatie\ResponseCache\CacheProfiles\CacheAllSuccessfulGetRequests;
@@ -85,7 +86,19 @@ class CacheAllSuccessfulGetRequestsTest extends TestCase
     public function it_will_determine_to_cache_responses_for_a_certain_amount_of_time()
     {
         /** @var $expirationDate \Carbon\Carbon */
-        $expirationDate = $this->cacheProfile->cacheRequestUntil($this->createRequest('get'));
+        $expirationDate = $this->cacheProfile->cacheRequestUntil($this->createRequest('get'), $this->createResponse(200));
+
+        $this->assertTrue($expirationDate->isFuture());
+    }
+
+    /** @test */
+    public function it_will_determine_to_cache_responses_based_on_expires_header()
+    {
+        /** @var $expirationDate \Carbon\Carbon */
+        $expirationDate = $this->cacheProfile->cacheRequestUntil(
+            $this->createRequest('get'),
+            $this->createResponse(200)->setExpires((new DateTime())->modify('+30 minutes'))
+        );
 
         $this->assertTrue($expirationDate->isFuture());
     }


### PR DESCRIPTION
This allows the ttl for the cache expiry to be set dynamically by the response suing the expires header (though other implementations could use different response attributes/headers). 

An example use for this is Event style pages, where you know that the content of the response will change at a point in time, like event opens, event starts, event stops accepting applications etc and so you want to use a value from a model rather than static or per route config 