### PR TITLE
Add cache bypass header

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ return [
      */
     'cache_profile' => Spatie\ResponseCache\CacheProfiles\CacheAllSuccessfulGetRequests::class,
 
+     *  Optionally, you can specify a header that will force a cache bypass.
+     *  This can be useful to monitor the performance of your application.
+     */
+    'cache_bypass_header' => [
+        'name' => env('CACHE_BYPASS_HEADER_NAME', null),
+        'value' => env('CACHE_BYPASS_HEADER_VALUE', null),
+    ],
+
     /*
      * When using the default CacheRequestFilter this setting controls the
      * default number of seconds responses must be cached.
@@ -281,6 +289,11 @@ class UserController extends Controller
     }
 }
 ```
+
+### Purposefully bypassing the cache
+
+It's possible to purposefully and securely bypass the cache and ensure you always receive a fresh response. This may be useful in case you want to profile some endpoint or in case you need to debug a response.
+In any case, all you need to do is fill the `CACHE_BYPASS_HEADER_NAME` and `CACHE_BYPASS_HEADER_VALUE` environment variables and then use that custom header when performing the requests.
 
 ### Creating a custom cache profile
 To determine which requests should be cached, and for how long, a cache profile class is used.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ return [
      */
     'cache_profile' => Spatie\ResponseCache\CacheProfiles\CacheAllSuccessfulGetRequests::class,
 
+    /*
      *  Optionally, you can specify a header that will force a cache bypass.
      *  This can be useful to monitor the performance of your application.
      */

--- a/config/responsecache.php
+++ b/config/responsecache.php
@@ -20,10 +20,10 @@ return [
      *  This can be useful to monitor the performance of your applicaton.
      */
     'cache_bypass_header' => [
-        'name' => env('cache_bypass_header_name', null),
-        'value' => env('cache_bypass_header_value', null),
+        'name' => env('CACHE_BYPASS_HEADER_NAME', null),
+        'value' => env('CACHE_BYPASS_HEADER_VALUE', null),
     ],
-    
+
     /*
      * When using the default CacheRequestFilter this setting controls the
      * default number of seconds responses must be cached.

--- a/config/responsecache.php
+++ b/config/responsecache.php
@@ -17,7 +17,7 @@ return [
 
     /*
      *  Optionally, you can specify a header that will force a cache bypass.
-     *  This can be useful to monitor the performance of your applicaton.
+     *  This can be useful to monitor the performance of your application.
      */
     'cache_bypass_header' => [
         'name' => env('CACHE_BYPASS_HEADER_NAME', null),

--- a/config/responsecache.php
+++ b/config/responsecache.php
@@ -16,6 +16,15 @@ return [
     'cache_profile' => Spatie\ResponseCache\CacheProfiles\CacheAllSuccessfulGetRequests::class,
 
     /*
+     *  Optionally, you can specify a header that will force a cache bypass.
+     *  This can be useful to monitor the performance of your applicaton.
+     */
+    'cache_bypass_header' => [
+        'name' => env('cache_bypass_header_name', null),
+        'value' => env('cache_bypass_header_value', null),
+    ],
+    
+    /*
      * When using the default CacheRequestFilter this setting controls the
      * default number of seconds responses must be cached.
      */

--- a/src/CacheProfiles/BaseCacheProfile.php
+++ b/src/CacheProfiles/BaseCacheProfile.php
@@ -36,4 +36,18 @@ abstract class BaseCacheProfile implements CacheProfile
 
         return app()->runningInConsole();
     }
+
+    public function requestHasCacheBypassHeader(Request $request): bool
+    {
+        // Ensure we return if cache_bypass_header is not setup
+        if (! config('responsecache.cache_bypass_header.name')) {
+            return false;
+        }
+        // Ensure we return if cache_bypass_header is not setup
+        if (! config('responsecache.cache_bypass_header.value')) {
+            return false;
+        }
+
+        return $request->header(config('responsecache.cache_bypass_header.name')) === config('responsecache.cache_bypass_header.value');
+    }
 }

--- a/src/CacheProfiles/CacheAllSuccessfulGetRequests.php
+++ b/src/CacheProfiles/CacheAllSuccessfulGetRequests.php
@@ -18,7 +18,7 @@ class CacheAllSuccessfulGetRequests extends BaseCacheProfile
             return false;
         }
 
-        if ($this->requestHasCacheBypassHeader(request)) {
+        if ($this->requestHasCacheBypassHeader($request)) {
             return false;
         }
 

--- a/src/CacheProfiles/CacheAllSuccessfulGetRequests.php
+++ b/src/CacheProfiles/CacheAllSuccessfulGetRequests.php
@@ -18,6 +18,10 @@ class CacheAllSuccessfulGetRequests extends BaseCacheProfile
             return false;
         }
 
+        if ($this->requestHasCacheBypassHeader(request)) {
+            return false;
+        }
+
         return $request->isMethod('get');
     }
 

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -275,4 +275,17 @@ class IntegrationTest extends TestCase
 
         $this->assertSameResponse($firstResponse, $secondResponse);
     }
+
+    /** @test */
+    public function it_wont_serve_cached_response_if_request_has_bypass_header()
+    {
+        $headerName = 'X-Cache-Bypass';
+        $headerValue = rand(1, 99999);
+        $this->app['config']->set('responsecache.cache_bypass_header.name', $headerName);
+        $this->app['config']->set('responsecache.cache_bypass_header.value', $headerValue);
+
+        $response = $this->get('/', ['X-Cache-Bypass' => $headerValue]);
+
+        $this->assertRegularResponse($response);
+    }
 }


### PR DESCRIPTION
👋  hi!

What do you think of adding a way of bypassing the cache?

Our use case is that we want to monitor the performance of parts of our app, and we want to get data for both cached and non cached responses. We'd actually add this header in Oh Dear.

I was working on adding this functionality to our custom `ResponseCacheProfile` and wondered if others might find it useful too.