### PR TITLE
Cache bypass header now also prevents an already cached response from being returned

### DIFF
--- a/src/CacheProfiles/BaseCacheProfile.php
+++ b/src/CacheProfiles/BaseCacheProfile.php
@@ -36,18 +36,4 @@ abstract class BaseCacheProfile implements CacheProfile
 
         return app()->runningInConsole();
     }
-
-    public function requestHasCacheBypassHeader(Request $request): bool
-    {
-        // Ensure we return if cache_bypass_header is not setup
-        if (! config('responsecache.cache_bypass_header.name')) {
-            return false;
-        }
-        // Ensure we return if cache_bypass_header is not setup
-        if (! config('responsecache.cache_bypass_header.value')) {
-            return false;
-        }
-
-        return $request->header(config('responsecache.cache_bypass_header.name')) === config('responsecache.cache_bypass_header.value');
-    }
 }

--- a/src/CacheProfiles/CacheAllSuccessfulGetRequests.php
+++ b/src/CacheProfiles/CacheAllSuccessfulGetRequests.php
@@ -18,10 +18,6 @@ class CacheAllSuccessfulGetRequests extends BaseCacheProfile
             return false;
         }
 
-        if ($this->requestHasCacheBypassHeader($request)) {
-            return false;
-        }
-
         return $request->isMethod('get');
     }
 

--- a/src/Middlewares/CacheResponse.php
+++ b/src/Middlewares/CacheResponse.php
@@ -26,7 +26,7 @@ class CacheResponse
         $lifetimeInSeconds = $this->getLifetime($args);
         $tags = $this->getTags($args);
 
-        if ($this->responseCache->enabled($request)) {
+        if ($this->responseCache->enabled($request) && ! $this->responseCache->shouldBypass($request)) {
             if ($this->responseCache->hasBeenCached($request, $tags)) {
                 event(new ResponseCacheHit($request));
 
@@ -44,7 +44,7 @@ class CacheResponse
 
         $response = $next($request);
 
-        if ($this->responseCache->enabled($request)) {
+        if ($this->responseCache->enabled($request) && ! $this->responseCache->shouldBypass($request)) {
             if ($this->responseCache->shouldCache($request, $response)) {
                 $this->makeReplacementsAndCacheResponse($request, $response, $lifetimeInSeconds, $tags);
             }

--- a/src/ResponseCache.php
+++ b/src/ResponseCache.php
@@ -37,6 +37,20 @@ class ResponseCache
         return $this->cacheProfile->shouldCacheResponse($response);
     }
 
+    public function shouldBypass(Request $request): bool
+    {
+        // Ensure we return if cache_bypass_header is not setup
+        if (! config('responsecache.cache_bypass_header.name')) {
+            return false;
+        }
+        // Ensure we return if cache_bypass_header is not setup
+        if (! config('responsecache.cache_bypass_header.value')) {
+            return false;
+        }
+
+        return $request->header(config('responsecache.cache_bypass_header.name')) === (string) config('responsecache.cache_bypass_header.value');
+    }
+
     public function cacheResponse(
         Request $request,
         Response $response,

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -277,15 +277,17 @@ class IntegrationTest extends TestCase
     }
 
     /** @test */
-    public function it_wont_serve_cached_response_if_request_has_bypass_header()
+    public function it_wont_cache_nor_serve_a_cached_response_if_request_has_bypass_header()
     {
         $headerName = 'X-Cache-Bypass';
         $headerValue = rand(1, 99999);
         $this->app['config']->set('responsecache.cache_bypass_header.name', $headerName);
         $this->app['config']->set('responsecache.cache_bypass_header.value', $headerValue);
 
-        $response = $this->get('/', ['X-Cache-Bypass' => $headerValue]);
+        $firstResponse = $this->get('/', ['X-Cache-Bypass' => $headerValue]);
+        $secondResponse = $this->get('/', ['X-Cache-Bypass' => $headerValue]);
 
-        $this->assertRegularResponse($response);
+        $this->assertRegularResponse($firstResponse);
+        $this->assertRegularResponse($secondResponse);
     }
 }


### PR DESCRIPTION
Follow up from https://github.com/spatie/laravel-responsecache/pull/406

The previous implementation had a bug by which responsecache would return a previously cached response, even if the request had valid bypass headers.

I'm a bit concern that this refactor might cause a breaking change if someone is already using the `requestHasCacheBypassHeader` method from BaseCacheProfile, since I removed it. I think the current implementation is simpler and more clear, but I'm of course open to adding it back.