### PR TITLE
Catch CouldNotUnserialize exception and continue returning a response

### DIFF
--- a/src/Middlewares/CacheResponse.php
+++ b/src/Middlewares/CacheResponse.php
@@ -30,8 +30,10 @@ class CacheResponse
 
         if ($this->responseCache->enabled($request) && ! $this->responseCache->shouldBypass($request)) {
             try {
-                if ($response = $this->responseCache->getCachedResponseFor($request, $tags)) {
+                if ($this->responseCache->hasBeenCached($request, $tags)) {
                     event(new ResponseCacheHit($request));
+
+                    $response = $this->responseCache->getCachedResponseFor($request, $tags);
 
                     $response = $this->addCacheAgeHeader($response);
 

--- a/src/Middlewares/CacheResponse.php
+++ b/src/Middlewares/CacheResponse.php
@@ -44,7 +44,8 @@ class CacheResponse
                     return $response;
                 }
             } catch (CouldNotUnserialize $e) {
-                Log::error("Could not unserialize response, returning uncached response instead. Error: {$e->getMessage()}");
+                report("Could not unserialize response, returning uncached response instead. Error: {$e->getMessage()}");
+                event(new CacheMissed($request));
             }
         }
 

--- a/src/Middlewares/CacheResponse.php
+++ b/src/Middlewares/CacheResponse.php
@@ -6,8 +6,10 @@ use Carbon\Carbon;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
 use Spatie\ResponseCache\Events\CacheMissed;
 use Spatie\ResponseCache\Events\ResponseCacheHit;
+use Spatie\ResponseCache\Exceptions\CouldNotUnserialize;
 use Spatie\ResponseCache\Replacers\Replacer;
 use Spatie\ResponseCache\ResponseCache;
 use Symfony\Component\HttpFoundation\Response;
@@ -27,18 +29,20 @@ class CacheResponse
         $tags = $this->getTags($args);
 
         if ($this->responseCache->enabled($request) && ! $this->responseCache->shouldBypass($request)) {
-            if ($this->responseCache->hasBeenCached($request, $tags)) {
-                event(new ResponseCacheHit($request));
+            try {
+                if ($response = $this->responseCache->getCachedResponseFor($request, $tags)) {
+                    event(new ResponseCacheHit($request));
 
-                $response = $this->responseCache->getCachedResponseFor($request, $tags);
+                    $response = $this->addCacheAgeHeader($response);
 
-                $response = $this->addCacheAgeHeader($response);
+                    $this->getReplacers()->each(function (Replacer $replacer) use ($response) {
+                        $replacer->replaceInCachedResponse($response);
+                    });
 
-                $this->getReplacers()->each(function (Replacer $replacer) use ($response) {
-                    $replacer->replaceInCachedResponse($response);
-                });
-
-                return $response;
+                    return $response;
+                }
+            } catch (CouldNotUnserialize $e) {
+                Log::error('Could not unserialize response, returning uncached response intead. Error: '.$e->getMessage());
             }
         }
 

--- a/src/Middlewares/CacheResponse.php
+++ b/src/Middlewares/CacheResponse.php
@@ -42,7 +42,7 @@ class CacheResponse
                     return $response;
                 }
             } catch (CouldNotUnserialize $e) {
-                Log::error('Could not unserialize response, returning uncached response intead. Error: '.$e->getMessage());
+                Log::error("Could not unserialize response, returning uncached response instead. Error: {$e->getMessage()}");
             }
         }
 


### PR DESCRIPTION
- Removes `hasBeenCached` which adds an extra unnecessary hit on the cache.
- Catches `CouldNotUnserialize` and logs it, instead of throwing to the User and continues with an uncached response.

Reference issue #342