### PR TITLE
Always prepend app url to requests

### DIFF
--- a/src/CacheItemSelector/AbstractRequestBuilder.php
+++ b/src/CacheItemSelector/AbstractRequestBuilder.php
@@ -81,10 +81,8 @@ abstract class AbstractRequestBuilder
 
     protected function build(string $uri): Request
     {
-        $uri = config('app.url') . $uri;
-
         $request = Request::create(
-            $uri,
+            url($uri),
             $this->method,
             $this->parameters,
             $this->cookies,

--- a/src/CacheItemSelector/AbstractRequestBuilder.php
+++ b/src/CacheItemSelector/AbstractRequestBuilder.php
@@ -81,6 +81,8 @@ abstract class AbstractRequestBuilder
 
     protected function build(string $uri): Request
     {
+        $uri = config('app.url') . $uri;
+
         $request = Request::create(
             $uri,
             $this->method,

--- a/tests/CacheItemSelectorIntegrationTest.php
+++ b/tests/CacheItemSelectorIntegrationTest.php
@@ -33,8 +33,6 @@ class CacheItemSelectorIntegrationTest extends TestCase
     /** @test */
     public function it_can_forget_a_specific_cached_request_using_cache_cleaner()
     {
-        config()->set('app.url', 'http://spatie.be');
-
         $firstResponse = $this->get('/random?foo=bar');
         $this->assertRegularResponse($firstResponse);
 
@@ -50,8 +48,6 @@ class CacheItemSelectorIntegrationTest extends TestCase
     /** @test */
     public function it_can_forget_a_specific_cached_request_using_cache_cleaner_post()
     {
-        config()->set('app.url', 'http://spatie.be');
-
         $firstResponse = $this->post('/random');
         $this->assertRegularResponse($firstResponse);
 
@@ -109,8 +105,6 @@ class CacheItemSelectorIntegrationTest extends TestCase
     /** @test */
     public function it_can_forget_a_specific_cached_request_using_cache_cleaner_suffix()
     {
-        config()->set('app.url', 'http://spatie.be');
-
         $userId = 1;
 
         $this->actingAs(User::findOrFail($userId));

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -86,8 +86,6 @@ class IntegrationTest extends TestCase
     /** @test */
     public function it_can_forget_a_specific_cached_request()
     {
-        config()->set('app.url', 'http://spatie.be');
-
         $firstResponse = $this->get('/random');
         $this->assertRegularResponse($firstResponse);
 


### PR DESCRIPTION
Before this `forget` with URLs only works on localhost.

More background on [this discussion](https://github.com/spatie/laravel-responsecache/discussions/372#discussioncomment-2698167).