### PR TITLE
Dispatch clear events when using facade

### DIFF
--- a/src/Facades/ResponseCache.php
+++ b/src/Facades/ResponseCache.php
@@ -4,6 +4,9 @@ namespace Spatie\ResponseCache\Facades;
 
 use Illuminate\Support\Facades\Facade;
 
+/**
+ * @method static void clear()
+ */
 class ResponseCache extends Facade
 {
     protected static function getFacadeAccessor(): string

--- a/src/ResponseCache.php
+++ b/src/ResponseCache.php
@@ -6,6 +6,8 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
 use Spatie\ResponseCache\CacheItemSelector\CacheItemSelector;
 use Spatie\ResponseCache\CacheProfiles\CacheProfile;
+use Spatie\ResponseCache\Events\ClearedResponseCache;
+use Spatie\ResponseCache\Events\ClearingResponseCache;
 use Spatie\ResponseCache\Hasher\RequestHasher;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -84,7 +86,11 @@ class ResponseCache
 
     public function clear(array $tags = []): void
     {
+        event(new ClearingResponseCache());
+
         $this->taggedCache($tags)->clear();
+
+        event(new ClearedResponseCache());
     }
 
     protected function addCachedHeader(Response $response): Response


### PR DESCRIPTION
Hello folks!

First of all, thank you all for creating this package.

Currently, I'm working in a application that uses the `Spatie\ResponseCache\Facades\ResponseCache@clear` to clear the response cache, and I need perform some work when the cache is cleared. At the moment,  the `Spatie\ResponseCache\Events\ClearedResponseCache` and `Spatie\ResponseCache\Events\ClearingResponseCache` events are dispatched only when clearing the cache using the `responsecache:clear` artisan command, so I can't listen to this events when using the package facade.

This PR adds this two events to the `clear` method in `Spatie\ResponseCache\ResponseCache` class.

PS.: I want to add tests but I'm not sure in which Test I'd do it.