### PR TITLE
Remove the cache enabled check from the hasBeenCached method

### DIFF
--- a/src/ResponseCache.php
+++ b/src/ResponseCache.php
@@ -74,9 +74,7 @@ class ResponseCache
 
     public function hasBeenCached(Request $request, array $tags = []): bool
     {
-        return config('responsecache.enabled')
-            ? $this->taggedCache($tags)->has($this->hasher->getHashFor($request))
-            : false;
+        return $this->taggedCache($tags)->has($this->hasher->getHashFor($request));
     }
 
     public function getCachedResponseFor(Request $request, array $tags = []): Response


### PR DESCRIPTION
This PR removes a redundant check on the value of the `responsecache.enabled` config value when calling `hasBeenCached`:
- imho, this method should not check this value, as it's not its responsibility
- the check is already done in the `handle` method: `if ($this->responseCache->enabled($request) && ...) { if ($this->responseCache->hasBeenCached($request, $tags)) { ... }}`
- the direct call to `config('responsecache.enabled')` does not use the `enabled(): bool` method existing in the same class, and does not let the developer choosing when to enable cache or not by using a custom `CacheProfile`

If the check is really required in this method, what about using `return $this->enabled($request) && $this->taggedCache($tags)->has($this->hasher->getHashFor($request))` instead ?