### PR TITLE
Add PHP 8.2 Support to tests workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.1, 8.0]
+        php: [8.2, 8.1, 8.0]
         laravel: [9.*, 8.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
This PR adds PHP 8.2 to the tests workflow and bumps the `checkout` action version to v3.