### PR TITLE
Normalize query string parameters before hashing

### DIFF
--- a/src/Hasher/DefaultHasher.php
+++ b/src/Hasher/DefaultHasher.php
@@ -21,6 +21,23 @@ class DefaultHasher implements RequestHasher
             "{$request->getHost()}-{$request->getRequestUri()}-{$request->getMethod()}/$cacheNameSuffix"
         );
     }
+    public function getHashFor(Request $request): string
+    {
+        $cacheNameSuffix = $this->getCacheNameSuffix($request);
+
+        return 'responsecache-' . md5(
+            "{$request->getHost()}-{$this->getNormalizedRequestUri($request)}-{$request->getMethod()}/$cacheNameSuffix"
+        );
+    }
+
+    protected function getNormalizedRequestUri(Request $request): string
+    {
+        if (null !== $qs = $request->getQueryString()) {
+            $qs = '?'.$qs;
+        }
+
+        return $request->getBaseUrl().$request->getPathInfo().$qs;
+    }
 
     protected function getCacheNameSuffix(Request $request)
     {

--- a/src/Hasher/DefaultHasher.php
+++ b/src/Hasher/DefaultHasher.php
@@ -24,11 +24,11 @@ class DefaultHasher implements RequestHasher
 
     protected function getNormalizedRequestUri(Request $request): string
     {
-        if (null !== $qs = $request->getQueryString()) {
-            $qs = '?'.$qs;
+        if ($queryString =  $request->getQueryString()) {
+            $queryString = '?'.$queryString;
         }
 
-        return $request->getBaseUrl().$request->getPathInfo().$qs;
+        return $request->getBaseUrl().$request->getPathInfo().$queryString;
     }
 
     protected function getCacheNameSuffix(Request $request)

--- a/src/Hasher/DefaultHasher.php
+++ b/src/Hasher/DefaultHasher.php
@@ -18,14 +18,6 @@ class DefaultHasher implements RequestHasher
         $cacheNameSuffix = $this->getCacheNameSuffix($request);
 
         return 'responsecache-' . md5(
-            "{$request->getHost()}-{$request->getRequestUri()}-{$request->getMethod()}/$cacheNameSuffix"
-        );
-    }
-    public function getHashFor(Request $request): string
-    {
-        $cacheNameSuffix = $this->getCacheNameSuffix($request);
-
-        return 'responsecache-' . md5(
             "{$request->getHost()}-{$this->getNormalizedRequestUri($request)}-{$request->getMethod()}/$cacheNameSuffix"
         );
     }


### PR DESCRIPTION
When the URL is hashed, it relies on `Request@getRequestUri()`. This does not normal query parameters, so a request for `https://spatie.be/cached-pages?page=1&per_page=10` is not the same as `https://spatie.be/cached-pages?per_page=10&page=1` (or even `https://spatie.be/cached-pages?page=1&per_page=10&`)

By normalizing the parameters this reduces cache misses for what is ultimately the same content.