### PR TITLE
Property name changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ protected $middlewareGroups = [
 
 ...
 
-protected $routeMiddleware = [
+protected $middlewareAliases = [
    ...
    'doNotCacheResponse' => \Spatie\ResponseCache\Middlewares\DoNotCacheResponse::class,
 ];


### PR DESCRIPTION
In Laravel 10 the $routeMiddleware property of the App\Http\Kernel class has been renamed to $middlewareAliases.