### PR TITLE
Fix badge for `run-tests` workflow in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/spatie/laravel-responsecache.svg?style=flat-square)](https://packagist.org/packages/spatie/laravel-responsecache)
 [![MIT Licensed](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
-![Psalm](https://github.com/spatie/laravel-responsecache/workflows/psalm/badge.svg)
+![Tests](https://github.com/spatie/laravel-responsecache/actions/workflows/run-tests.yml/badge.svg)
 [![Total Downloads](https://img.shields.io/packagist/dt/spatie/laravel-responsecache.svg?style=flat-square)](https://packagist.org/packages/spatie/laravel-responsecache)
 
 This Laravel package can cache an entire response. By default it will cache all successful get-requests that return text based content (such as html and json) for a week. This could potentially speed up the response quite considerably.


### PR DESCRIPTION
Before:

<img width="861" alt="image" src="https://user-images.githubusercontent.com/1460709/231344707-1ecaad58-463c-48be-ae4d-1e21b2cbfd29.png">

After:

<img width="1034" alt="image" src="https://user-images.githubusercontent.com/1460709/231344667-01ecf063-6e2a-44e6-aca9-915fb4dce8ef.png">
