### PR TITLE
Do not enable cache time header by default

### DIFF
--- a/config/responsecache.php
+++ b/config/responsecache.php
@@ -35,7 +35,7 @@ return [
      * should be added to a cached response. This can be handy when
      * debugging.
      */
-    'add_cache_time_header' => env('APP_DEBUG', true),
+    'add_cache_time_header' => env('APP_DEBUG', false),
 
     /*
      * This setting determines the name of the http header that contains


### PR DESCRIPTION
I don't think someone wants to expose this header by default, as it states it's useful for debugging.

The other (debugging) header, is also disabled by default.