### PR TITLE
Generate the cache at the end of all

### DIFF
--- a/src/ResponseCacheServiceProvider.php
+++ b/src/ResponseCacheServiceProvider.php
@@ -9,6 +9,7 @@ use Spatie\LaravelPackageTools\PackageServiceProvider;
 use Spatie\ResponseCache\CacheProfiles\CacheProfile;
 use Spatie\ResponseCache\Commands\ClearCommand;
 use Spatie\ResponseCache\Hasher\RequestHasher;
+use Spatie\ResponseCache\Middlewares\CacheResponse;
 use Spatie\ResponseCache\Serializers\Serializer;
 
 class ResponseCacheServiceProvider extends PackageServiceProvider

--- a/src/ResponseCacheServiceProvider.php
+++ b/src/ResponseCacheServiceProvider.php
@@ -49,5 +49,8 @@ class ResponseCacheServiceProvider extends PackageServiceProvider
             });
 
         $this->app->singleton('responsecache', ResponseCache::class);
+        
+        $this->app->singleton(CacheResponse::class);
+            
     }
 }


### PR DESCRIPTION
When using this package with Livewire we found that Livewire assets were not injected correctly.

This happened because Livewire dynamically injects this after the cache is generated.

For this reason we have had the cache generated in the Middleware terminate() to ensure that we save the complete response with all possible changes.