### PR TITLE
Cast cache lifetime to integer by default

### DIFF
--- a/config/responsecache.php
+++ b/config/responsecache.php
@@ -28,7 +28,7 @@ return [
      * When using the default CacheRequestFilter this setting controls the
      * default number of seconds responses must be cached.
      */
-    'cache_lifetime_in_seconds' => env('RESPONSE_CACHE_LIFETIME', 60 * 60 * 24 * 7),
+    'cache_lifetime_in_seconds' => (int) env('RESPONSE_CACHE_LIFETIME', 60 * 60 * 24 * 7),
 
     /*
      * This setting determines if a http header named with the cache time


### PR DESCRIPTION
This may be specific to my production environment (Heroku) but I can into this issue when upgrading to Laravel 11, specifically with Carbon 3. I have `responsecache.cache_lifetime_in_seconds` set in my production environment Laravel pulls it into the config as a string.

Carbon 3 blows up when passing a string to [`addSeconds` here](https://github.com/spatie/laravel-responsecache/blob/main/src/CacheProfiles/BaseCacheProfile.php#L17-L22). Carbon 2 had no issues with accepting a string.

```php
public function cacheRequestUntil(Request $request): DateTime
{
    return Carbon::now()->addSeconds(
        config('responsecache.cache_lifetime_in_seconds')
    );
}
```

Laravel 11 does include new config helpers to ensure you get a certain type (`Config::integer()` for example) but we can't use that here without dropping support for previous versions of Laravel.

I've made this change in my app already but thought it was worthwhile to propose to include by default as more applications will adopt Carbon 3 alongside Laravel 11 and this makes the configuration value explicit.
