### PR TITLE
Compatibility Update for nestbot/carbon^3.0 and Fix for Type Error in Response Cache Update

### DIFF
--- a/src/CacheProfiles/BaseCacheProfile.php
+++ b/src/CacheProfiles/BaseCacheProfile.php
@@ -17,7 +17,7 @@ abstract class BaseCacheProfile implements CacheProfile
     public function cacheRequestUntil(Request $request): DateTime
     {
         return Carbon::now()->addSeconds(
-            config('responsecache.cache_lifetime_in_seconds')
+            (int) config('responsecache.cache_lifetime_in_seconds')
         );
     }
 


### PR DESCRIPTION
added compatibility for nestbot/carbon^3.0 by updating the version of carbon to ^3.0 in our project. However, during the update process, specifically when performing response caching, we encountered an error.

The dependency update in composer.json is as follows:

```json
        "nesbot/carbon": "^2.63|^3.0",
```

The error encountered is detailed below:

```php
Carbon\Carbon::rawAddUnit(): Argument #3 ($value) must be of type int|float, string given, called in /var/www/vendor/nesbot/carbon/src/Carbon/Traits/Units.php on line 356 (CODE: 0)
```

![image](https://github.com/spatie/laravel-responsecache/assets/17328737/6ec78bca-4dcb-4c81-9fed-30516123375b)
