### PR TITLE
Add missing Laravel 11.x Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ And finally you should install the provided middlewares `\Spatie\ResponseCache\M
 
 **For laravel 11.x and newer:**
 
-Add the middleware definitions the bootstrap app.
+Add the middleware definitions to the bootstrap app.
 
 ```php
 // bootstrap/app.php
@@ -166,7 +166,7 @@ Add the middleware definitions the bootstrap app.
 
 **For laravel 10.x and earlier:**
 
-Add the middleware definitions the http kernel.
+Add the middleware definitions to the http kernel.
 
 
 ```php

--- a/README.md
+++ b/README.md
@@ -136,7 +136,37 @@ return [
 ];
 ```
 
-And finally you should install the provided middlewares `\Spatie\ResponseCache\Middlewares\CacheResponse::class` and `\Spatie\ResponseCache\Middlewares\DoNotCacheResponse` in the http kernel.
+And finally you should install the provided middlewares `\Spatie\ResponseCache\Middlewares\CacheResponse::class` and `\Spatie\ResponseCache\Middlewares\DoNotCacheResponse`.
+
+
+**For laravel 11.x and newer:**
+
+Add the middleware definitions the bootstrap app.
+
+```php
+// bootstrap/app.php
+
+
+->withMiddleware(function (Middleware $middleware) {
+    ...
+    $middleware->web(append: [
+        ...
+        \Spatie\ResponseCache\Middlewares\CacheResponse::class,
+    ]);
+
+    ...
+
+    $middleware->alias([
+        ...
+        'doNotCacheResponse' => \Spatie\ResponseCache\Middlewares\DoNotCacheResponse::class,
+    ]);
+})
+
+```
+
+**For laravel 10.x and earlier:**
+
+Add the middleware definitions the http kernel.
 
 
 ```php


### PR DESCRIPTION
* Add the middleware documentation for laravel 11.x
* Refactor the middleware documentation for laravel 10.x and earlier.