### PR TITLE
Switch DefaultHasher to xxh128 for a faster alternative to MD5.

### DIFF
--- a/src/Hasher/DefaultHasher.php
+++ b/src/Hasher/DefaultHasher.php
@@ -17,7 +17,8 @@ class DefaultHasher implements RequestHasher
     {
         $cacheNameSuffix = $this->getCacheNameSuffix($request);
 
-        return 'responsecache-' . md5(
+        return 'responsecache-' . hash(
+            'xxh128',
             "{$request->getHost()}-{$this->getNormalizedRequestUri($request)}-{$request->getMethod()}/$cacheNameSuffix"
         );
     }

--- a/tests/ResponseHasherTest.php
+++ b/tests/ResponseHasherTest.php
@@ -20,7 +20,7 @@ it('can generate a hash for a request', function () {
     $this->cacheProfile->shouldReceive('useCacheNameSuffix')->andReturn('cacheProfileSuffix');
 
     assertEquals(
-        'responsecache-467d6e9cb7425ed9d3e114e44eb7117f',
+        'responsecache-9937bec32aa1918917ad64b2b25f2982',
         $this->requestHasher->getHashFor($this->request)
     );
 });


### PR DESCRIPTION
Update DefaultHasher to use xxh128 for a faster alternative to MD5, while maintaining the same hash size.

- See https://xxhash.com/
- Laravel is considering replacing MD5 with xxh128: https://github.com/laravel/framework/pull/52301