### PR TITLE
Fix ResponseCache Facade docblock for forget()

### DIFF
--- a/src/Facades/ResponseCache.php
+++ b/src/Facades/ResponseCache.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Facade;
 
 /**
  * @method static void clear(array $tags = [])
- * @method static void forget(string|array $key)
+ * @method static void forget(string|array $key, array $tags = [])
  * @method static bool enabled(\Illuminate\Http\Request $request)
  * @method static bool shouldCache(\Illuminate\Http\Request $request, \Symfony\Component\HttpFoundation\Response $response)
  * @method static bool shouldBypass(\Illuminate\Http\Request $request)


### PR DESCRIPTION
Quick fix for `ResponseCache` Facade's docblock for the `forget()` method signature.