### PR TITLE
fix DocBlock in ResponseCache Facade

### DIFF
--- a/src/Facades/ResponseCache.php
+++ b/src/Facades/ResponseCache.php
@@ -13,7 +13,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static \Symfony\Component\HttpFoundation\Response cacheResponse(\Illuminate\Http\Request $request, \Symfony\Component\HttpFoundation\Response $response, ?int $lifetimeInSeconds = null, array $tags = [])
  * @method static bool hasBeenCached(\Illuminate\Http\Request $request, array $tags = [])
  * @method static \Symfony\Component\HttpFoundation\Response getCachedResponseFor(\Illuminate\Http\Request $request, array $tags = [])
- * @method static Spatie\ResponseCache\CacheItemSelector\CacheItemSelector selectCachedItems()
+ * @method static \Spatie\ResponseCache\CacheItemSelector\CacheItemSelector selectCachedItems()
  */
 class ResponseCache extends Facade
 {


### PR DESCRIPTION
Hi,
Fixed the DocBlock for return type, as phpstan was reporting the following error:

```
Call to method forUrls() on an unknown class Spatie\ResponseCache\Facades\Spatie\ResponseCache\CacheItemSelector\CacheItemSelector.
         🪪  class.notFound
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols
```

This correction resolves the issue with the unknown class reference in static analysis.