### PR TITLE
Fix Carbon3 diffInSeconds to use int and not float

### DIFF
--- a/src/Middlewares/CacheResponse.php
+++ b/src/Middlewares/CacheResponse.php
@@ -126,7 +126,7 @@ class CacheResponse
     public function addCacheAgeHeader(Response $response): Response
     {
         if (config('responsecache.add_cache_age_header') and $time = $response->headers->get(config('responsecache.cache_time_header_name'))) {
-            $ageInSeconds = Carbon::parse($time)->diffInSeconds(Carbon::now());
+            $ageInSeconds = (int) Carbon::parse($time)->diffInSeconds(Carbon::now(), true);
 
             $response->headers->set(config('responsecache.cache_age_header_name'), $ageInSeconds);
         }


### PR DESCRIPTION
I noticed that Carbon 3, diffIn functions now return floats, this PR fixes it so int is used as seconds