### PR TITLE
Optimize response caching by reducing unnecessary `hasBeenCached` met…

### DIFF
--- a/src/Middlewares/CacheResponse.php
+++ b/src/Middlewares/CacheResponse.php
@@ -108,6 +108,10 @@ class CacheResponse extends BaseCacheMiddleware
 
         try {
             $response = $this->responseCache->getCachedResponseFor($request, $tags);
+
+            if ($response === null) {
+                return null;
+            }
         } catch (Throwable $exception) {
             report("Could not serve cached response: {$exception->getMessage()}");
 

--- a/src/Middlewares/CacheResponse.php
+++ b/src/Middlewares/CacheResponse.php
@@ -104,10 +104,6 @@ class CacheResponse extends BaseCacheMiddleware
 
     protected function getCachedResponse(Request $request, array $tags): ?Response
     {
-        if (! $this->responseCache->hasBeenCached($request, $tags)) {
-            return null;
-        }
-
         $cacheKey = app(RequestHasher::class)->getHashFor($request);
 
         try {

--- a/src/ResponseCache.php
+++ b/src/ResponseCache.php
@@ -78,7 +78,7 @@ class ResponseCache
             : false;
     }
 
-    public function getCachedResponseFor(Request $request, array $tags = []): Response
+    public function getCachedResponseFor(Request $request, array $tags = []): ?Response
     {
         return $this->taggedCache($tags)->get($this->hasher->getHashFor($request));
     }

--- a/src/ResponseCacheRepository.php
+++ b/src/ResponseCacheRepository.php
@@ -48,9 +48,15 @@ class ResponseCacheRepository
         return $this->cache->has($key);
     }
 
-    public function get(string $key): Response
+    public function get(string $key): ?Response
     {
-        return $this->responseSerializer->unserialize($this->cache->get($key) ?? '');
+        $cachedValue = $this->cache->get($key);
+
+        if ($cachedValue === null) {
+            return null;
+        }
+
+        return $this->responseSerializer->unserialize($cachedValue);
     }
 
     /**

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -242,3 +242,17 @@ it('wont cache nor serve a cached response if request has bypass header', functi
     assertRegularResponse($firstResponse);
     assertRegularResponse($secondResponse);
 });
+
+it('performs only one cache query per request, not two', function () {
+    $spy = $this->spy(Spatie\ResponseCache\ResponseCache::class);
+
+    $spy->shouldReceive('enabled')->andReturn(true);
+    $spy->shouldReceive('shouldBypass')->andReturn(false);
+    $spy->shouldReceive('shouldCache')->andReturn(false);
+    $spy->shouldReceive('getCachedResponseFor')->once()->andReturn(null);
+    $spy->shouldNotReceive('hasBeenCached');
+
+    $this->app->instance(Spatie\ResponseCache\ResponseCache::class, $spy);
+
+    $this->get('/random');
+});


### PR DESCRIPTION
…hod calls and adding an integration test.

I noticed in my application that sentry complained about N+1 query issues in the CacheResponse middleware.
It turned out this is because when laravel cache checks for a key in the cache (the has method), it actually calls the get method and compares if the result is null.

By removing the hasBeenCached we get rid of the duplicated query.

**This pull request is more of a question thought, the tests that fail make that think that this may have been on purpose or was embraced in the codebase.** If my change is welcome just let me know and I will also update the failing tests so everything is in order. Have a great day.