### PR TITLE
Fix #517: share cache state between handle/terminate via request attributes

### DIFF
--- a/config/responsecache.php
+++ b/config/responsecache.php
@@ -1,5 +1,10 @@
 <?php
 
+use Spatie\ResponseCache\CacheProfiles\CacheAllSuccessfulGetRequests;
+use Spatie\ResponseCache\Hasher\DefaultHasher;
+use Spatie\ResponseCache\Replacers\CsrfTokenReplacer;
+use Spatie\ResponseCache\Serializers\JsonSerializer;
+
 return [
     /*
      * Determine if the response cache middleware should be enabled.
@@ -96,18 +101,18 @@ return [
      * By default all successful GET-requests will be cached.
      * You can provide your own by using the CacheProfile.
      */
-    'cache_profile' => Spatie\ResponseCache\CacheProfiles\CacheAllSuccessfulGetRequests::class,
+    'cache_profile' => CacheAllSuccessfulGetRequests::class,
 
     /*
      * This class is responsible for generating a hash for
      * a request. Used for looking up cached responses.
      */
-    'hasher' => \Spatie\ResponseCache\Hasher\DefaultHasher::class,
+    'hasher' => DefaultHasher::class,
 
     /*
      * This class is responsible for serializing responses.
      */
-    'serializer' => \Spatie\ResponseCache\Serializers\JsonSerializer::class,
+    'serializer' => JsonSerializer::class,
 
     /*
      * Here you may define the replacers that will replace
@@ -115,6 +120,6 @@ return [
      * must always implement the Replacer interface.
      */
     'replacers' => [
-        \Spatie\ResponseCache\Replacers\CsrfTokenReplacer::class,
+        CsrfTokenReplacer::class,
     ],
 ];

--- a/src/Middlewares/CacheResponse.php
+++ b/src/Middlewares/CacheResponse.php
@@ -19,12 +19,11 @@ use Throwable;
 
 class CacheResponse extends BaseCacheMiddleware
 {
-    private bool $shouldCache = false;
+    private const SHOULD_CACHE_ATTRIBUTE = '_response_cache.should_cache';
 
-    private ?int $pendingLifetime = null;
+    private const PENDING_LIFETIME_ATTRIBUTE = '_response_cache.pending_lifetime';
 
-    /** @var string[] */
-    private array $pendingTags = [];
+    private const PENDING_TAGS_ATTRIBUTE = '_response_cache.pending_tags';
 
     public function __construct(
         protected ResponseCache $responseCache,
@@ -48,10 +47,6 @@ class CacheResponse extends BaseCacheMiddleware
 
     public function handle(Request $request, Closure $next, ...$args): Response
     {
-        $this->shouldCache = false;
-        $this->pendingLifetime = null;
-        $this->pendingTags = [];
-
         $attribute = $this->getAttributeFromRequest($request);
 
         if ($attribute instanceof NoCache) {
@@ -80,9 +75,9 @@ class CacheResponse extends BaseCacheMiddleware
         $response = $next($request);
 
         if ($this->responseCache->shouldCache($request, $response)) {
-            $this->shouldCache = true;
-            $this->pendingLifetime = $lifetimeInSeconds;
-            $this->pendingTags = $tags;
+            $request->attributes->set(self::SHOULD_CACHE_ATTRIBUTE, true);
+            $request->attributes->set(self::PENDING_LIFETIME_ATTRIBUTE, $lifetimeInSeconds);
+            $request->attributes->set(self::PENDING_TAGS_ATTRIBUTE, $tags);
         }
 
         $cacheKey = app(RequestHasher::class)->getHashFor($request);
@@ -95,11 +90,16 @@ class CacheResponse extends BaseCacheMiddleware
 
     public function terminate(Request $request, Response $response): void
     {
-        if (! $this->shouldCache) {
+        if (! $request->attributes->get(self::SHOULD_CACHE_ATTRIBUTE, false)) {
             return;
         }
 
-        $this->cacheResponse($request, $response, $this->pendingLifetime, $this->pendingTags);
+        $this->cacheResponse(
+            $request,
+            $response,
+            $request->attributes->get(self::PENDING_LIFETIME_ATTRIBUTE),
+            $request->attributes->get(self::PENDING_TAGS_ATTRIBUTE, []),
+        );
     }
 
     protected function getCachedResponse(Request $request, array $tags): ?Response

--- a/src/Middlewares/CacheResponse.php
+++ b/src/Middlewares/CacheResponse.php
@@ -19,7 +19,7 @@ use Throwable;
 
 class CacheResponse extends BaseCacheMiddleware
 {
-    private const PENDING_CACHE_ATTRIBUTE = '_response_cache.pending';
+    protected string $pendingCacheAttribute = '_response_cache.pending';
 
     public function __construct(
         protected ResponseCache $responseCache,
@@ -71,7 +71,7 @@ class CacheResponse extends BaseCacheMiddleware
         $response = $next($request);
 
         if ($this->responseCache->shouldCache($request, $response)) {
-            $request->attributes->set(self::PENDING_CACHE_ATTRIBUTE, [
+            $request->attributes->set($this->pendingCacheAttribute, [
                 'lifetime' => $lifetimeInSeconds,
                 'tags' => $tags,
             ]);
@@ -87,7 +87,7 @@ class CacheResponse extends BaseCacheMiddleware
 
     public function terminate(Request $request, Response $response): void
     {
-        $pending = $request->attributes->get(self::PENDING_CACHE_ATTRIBUTE);
+        $pending = $request->attributes->get($this->pendingCacheAttribute);
 
         if (! $pending) {
             return;

--- a/src/Middlewares/CacheResponse.php
+++ b/src/Middlewares/CacheResponse.php
@@ -19,11 +19,7 @@ use Throwable;
 
 class CacheResponse extends BaseCacheMiddleware
 {
-    private const SHOULD_CACHE_ATTRIBUTE = '_response_cache.should_cache';
-
-    private const PENDING_LIFETIME_ATTRIBUTE = '_response_cache.pending_lifetime';
-
-    private const PENDING_TAGS_ATTRIBUTE = '_response_cache.pending_tags';
+    private const PENDING_CACHE_ATTRIBUTE = '_response_cache.pending';
 
     public function __construct(
         protected ResponseCache $responseCache,
@@ -75,9 +71,10 @@ class CacheResponse extends BaseCacheMiddleware
         $response = $next($request);
 
         if ($this->responseCache->shouldCache($request, $response)) {
-            $request->attributes->set(self::SHOULD_CACHE_ATTRIBUTE, true);
-            $request->attributes->set(self::PENDING_LIFETIME_ATTRIBUTE, $lifetimeInSeconds);
-            $request->attributes->set(self::PENDING_TAGS_ATTRIBUTE, $tags);
+            $request->attributes->set(self::PENDING_CACHE_ATTRIBUTE, [
+                'lifetime' => $lifetimeInSeconds,
+                'tags' => $tags,
+            ]);
         }
 
         $cacheKey = app(RequestHasher::class)->getHashFor($request);
@@ -90,16 +87,13 @@ class CacheResponse extends BaseCacheMiddleware
 
     public function terminate(Request $request, Response $response): void
     {
-        if (! $request->attributes->get(self::SHOULD_CACHE_ATTRIBUTE, false)) {
+        $pending = $request->attributes->get(self::PENDING_CACHE_ATTRIBUTE);
+
+        if (! $pending) {
             return;
         }
 
-        $this->cacheResponse(
-            $request,
-            $response,
-            $request->attributes->get(self::PENDING_LIFETIME_ATTRIBUTE),
-            $request->attributes->get(self::PENDING_TAGS_ATTRIBUTE, []),
-        );
+        $this->cacheResponse($request, $response, $pending['lifetime'], $pending['tags']);
     }
 
     protected function getCachedResponse(Request $request, array $tags): ?Response

--- a/tests/RequestHandledIntegrationTest.php
+++ b/tests/RequestHandledIntegrationTest.php
@@ -36,3 +36,20 @@ it('includes modifications made by RequestHandled listeners in the cached respon
 
     assertSameResponse($firstResponse, $secondResponse);
 });
+
+it('caches the response even when the middleware is resolved as a fresh instance in terminate', function () {
+    // Simulate environments where CacheResponse is not resolved as a singleton,
+    // so handle() and terminate() receive different instances. State must travel
+    // with the request instead of on the middleware object.
+    app()->bind(CacheResponse::class);
+
+    Route::get('/non-singleton', fn () => 'fresh content')
+        ->middleware(CacheResponse::class);
+
+    $firstResponse = $this->get('/non-singleton');
+    assertRegularResponse($firstResponse);
+
+    $secondResponse = $this->get('/non-singleton');
+    assertCachedResponse($secondResponse);
+    assertSameResponse($firstResponse, $secondResponse);
+});

--- a/tests/RequestHandledIntegrationTest.php
+++ b/tests/RequestHandledIntegrationTest.php
@@ -38,9 +38,7 @@ it('includes modifications made by RequestHandled listeners in the cached respon
 });
 
 it('caches the response even when the middleware is resolved as a fresh instance in terminate', function () {
-    // Simulate environments where CacheResponse is not resolved as a singleton,
-    // so handle() and terminate() receive different instances. State must travel
-    // with the request instead of on the middleware object.
+    // Override the singleton binding so handle() and terminate() receive different middleware instances.
     app()->bind(CacheResponse::class);
 
     Route::get('/non-singleton', fn () => 'fresh content')

--- a/tests/ResponseCacheRepositoryTest.php
+++ b/tests/ResponseCacheRepositoryTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Cache\ArrayStore;
 use Illuminate\Cache\Repository;
 use Illuminate\Testing\TestResponse;
 use Spatie\ResponseCache\Exceptions\CouldNotUnserialize;
@@ -21,7 +22,7 @@ it('will handle race conditions between has and get', function () {
 
     /** @var Serializer $responseSerializer */
     $responseSerializer = app(Serializer::class);
-    /** @var Illuminate\Cache\ArrayStore $cacheStore */
+    /** @var ArrayStore $cacheStore */
     $cacheStore = app('cache')
         ->store('array')
         ->getStore();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,6 +3,7 @@
 namespace Spatie\ResponseCache\Test;
 
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Application;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Route;
@@ -35,7 +36,7 @@ abstract class TestCase extends Orchestra
     }
 
     /**
-     * @param  \Illuminate\Foundation\Application  $app
+     * @param  Application  $app
      * @return array
      */
     protected function getPackageProviders($app)
@@ -53,7 +54,7 @@ abstract class TestCase extends Orchestra
     }
 
     /**
-     * @param  \Illuminate\Foundation\Application  $app
+     * @param  Application  $app
      */
     protected function getEnvironmentSetUp($app)
     {
@@ -68,7 +69,7 @@ abstract class TestCase extends Orchestra
     }
 
     /**
-     * @param  \Illuminate\Foundation\Application  $app
+     * @param  Application  $app
      */
     protected function setUpDatabase($app)
     {
@@ -95,7 +96,7 @@ abstract class TestCase extends Orchestra
     }
 
     /**
-     * @param  \Illuminate\Foundation\Application  $app
+     * @param  Application  $app
      */
     protected function setUpRoutes($app)
     {


### PR DESCRIPTION
Fixes #517.

## Problem

The state set in `CacheResponse::handle()` (`$shouldCache`, `$pendingLifetime`, `$pendingTags`) lives on the middleware instance. This only caches the response if Laravel resolves the same middleware instance in `terminate()`. When a fresh instance is resolved, `$shouldCache` is `false` and nothing gets cached, even though the response was meant to be cached.

The reporter worked around it by using `$request->attributes->set(...)` in their own copy of the middleware, which confirms the root cause.

## Fix

Move the deferred-cache state from instance properties to request attributes, so it travels with the request itself. This removes the dependency on the singleton binding for correctness.

## Test

`tests/RequestHandledIntegrationTest.php` now has a second test that rebinds `CacheResponse` as non-singleton (so `handle()` and `terminate()` receive different instances) and asserts the second request is still served from cache. Without the fix, that test fails with "Failed to assert that the response has been cached." With the fix, all 75 tests pass.