### PR TITLE
Treat null cache value as a miss to fix has/get race

### DIFF
--- a/src/Facades/ResponseCache.php
+++ b/src/Facades/ResponseCache.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Response;
  * @method static bool shouldBypass(Request $request)
  * @method static Response cacheResponse(Request $request, Response $response, ?int $lifetimeInSeconds = null, array $tags = [])
  * @method static bool hasBeenCached(Request $request, array $tags = [])
- * @method static Response getCachedResponseFor(Request $request, array $tags = [])
+ * @method static ?Response getCachedResponseFor(Request $request, array $tags = [])
  * @method static CacheItemSelector selectCachedItems()
  * @method static Response flexible(string $key, array $seconds, Closure $callback, array $tags = [])
  */

--- a/src/Middlewares/CacheResponse.php
+++ b/src/Middlewares/CacheResponse.php
@@ -98,10 +98,6 @@ class CacheResponse extends BaseCacheMiddleware
 
     protected function getCachedResponse(Request $request, array $tags): ?Response
     {
-        if (! $this->responseCache->hasBeenCached($request, $tags)) {
-            return null;
-        }
-
         $cacheKey = app(RequestHasher::class)->getHashFor($request);
 
         try {
@@ -109,6 +105,10 @@ class CacheResponse extends BaseCacheMiddleware
         } catch (Throwable $exception) {
             report("Could not serve cached response: {$exception->getMessage()}");
 
+            return null;
+        }
+
+        if ($response === null) {
             return null;
         }
 

--- a/src/ResponseCache.php
+++ b/src/ResponseCache.php
@@ -78,7 +78,7 @@ class ResponseCache
             : false;
     }
 
-    public function getCachedResponseFor(Request $request, array $tags = []): Response
+    public function getCachedResponseFor(Request $request, array $tags = []): ?Response
     {
         return $this->taggedCache($tags)->get($this->hasher->getHashFor($request));
     }

--- a/src/ResponseCacheRepository.php
+++ b/src/ResponseCacheRepository.php
@@ -48,9 +48,15 @@ class ResponseCacheRepository
         return $this->cache->has($key);
     }
 
-    public function get(string $key): Response
+    public function get(string $key): ?Response
     {
-        return $this->responseSerializer->unserialize($this->cache->get($key) ?? '');
+        $cachedValue = $this->cache->get($key);
+
+        if ($cachedValue === null) {
+            return null;
+        }
+
+        return $this->responseSerializer->unserialize($cachedValue);
     }
 
     /**

--- a/tests/ResponseCacheRepositoryTest.php
+++ b/tests/ResponseCacheRepositoryTest.php
@@ -1,52 +1,37 @@
 <?php
 
-use Illuminate\Cache\ArrayStore;
 use Illuminate\Cache\Repository;
-use Illuminate\Testing\TestResponse;
-use Spatie\ResponseCache\Exceptions\CouldNotUnserialize;
+use Illuminate\Support\Facades\Exceptions;
 use Spatie\ResponseCache\ResponseCacheRepository;
 use Spatie\ResponseCache\Serializers\Serializer;
 
-it('handles missed cache gracefully', function () {
-    // Instantiate a default serializer
+it('returns null when the cache has no value for the given key', function () {
     $responseSerializer = app(Serializer::class);
 
     $cacheRepository = Mockery::mock(Repository::class);
     $cacheRepository->shouldReceive('get')->with('missed-cache')->once()->andReturn(null);
 
     $repository = new ResponseCacheRepository($responseSerializer, $cacheRepository);
-    $repository->get('missed-cache');
-})->throws(CouldNotUnserialize::class);
 
-it('will handle race conditions between has and get', function () {
+    expect($repository->get('missed-cache'))->toBeNull();
+});
 
-    /** @var Serializer $responseSerializer */
-    $responseSerializer = app(Serializer::class);
-    /** @var ArrayStore $cacheStore */
-    $cacheStore = app('cache')
-        ->store('array')
-        ->getStore();
+it('treats a cache key that vanished mid-request as a miss without reporting', function () {
+    // Simulates the race where a cached key exists at one moment but the
+    // value is gone microseconds later (TTL expiry, eviction, or a
+    // concurrent forget). The middleware must treat this as a regular cache
+    // miss and serve a fresh response without reporting an exception.
+    Exceptions::fake();
 
-    // This order of operations simulates a cache lookup happening during a
-    // cache expiration or purge event. The `has()` call should succeed, but
-    // after that the cache has 'expired' and is unavailable.
-    $cachedValues = [
-        $responseSerializer->serialize(createResponse(200)),
-        null,
-    ];
+    $cacheStore = app('cache')->store('array')->getStore();
 
-    // We cannot use the partialMock helper because the cache store must be
-    // available and partialMock does not allow constructor arguments.
-    $cacheRepository = Mockery::mock(Repository::class, [$cacheStore]);
-    $cacheRepository
-        ->shouldReceive('get')
-        ->twice()
-        ->andReturns($cachedValues);
-    $cacheRepository->makePartial();
+    $cacheRepository = Mockery::mock(Repository::class, [$cacheStore])->makePartial();
+    $cacheRepository->shouldReceive('has')->andReturn(true);
+    $cacheRepository->shouldReceive('get')->andReturn(null);
     $this->instance(Repository::class, $cacheRepository);
 
-    /** @var TestResponse $response */
     $response = $this->get('/random');
+
     assertRegularResponse($response);
-    expect($response->exception)->toBeNull();
+    Exceptions::assertNothingReported();
 });


### PR DESCRIPTION
`CacheResponse::getCachedResponse()` does two separate cache calls — `hasBeenCached()`
followed by `getCachedResponseFor()`. The race:

1. `has()` returns `true` — the key exists.
2. The key expires, is evicted, or is removed by a concurrent `forget()` / `responsecache:clear`.
3. `get()` returns `null`.
4. `ResponseCacheRepository::get()` evaluates `unserialize($cache->get($key) ?? '')`  → `unserialize('')` →  `CouldNotUnserialize`.`
5. The middleware catches it, serves a fresh response (correct user-facing behaviour), and calls `report()`.

The end result is correct, but normal behaviour on any cache with a finite TTL under moderate traffic gets surfaced as an exception. This was hit in production: traces showed a cache hit and miss on the same key microseconds apart, on a TTL boundary.

The fix collapses the two calls into a single atomic `get()`: `null` means miss, `Response` means hit. The race window is closed and we save a cache round-trip per cached request. `hasBeenCached()` stays on the public API for external callers.

|                                | Before            | After   |
|--------------------------------|-------------------|---------|
| Cache calls per cached request | 2 (`has` + `get`) | 1 (`get`) |
| Race window                    | yes               | no      |
| Fresh response on race         | yes               | yes     |
| `report()` on race             | yes               | no      |