### PR TITLE
Fix forgetting multiple urls stopping at the first uncached url

### DIFF
--- a/src/CacheItemSelector/CacheItemSelector.php
+++ b/src/CacheItemSelector/CacheItemSelector.php
@@ -41,6 +41,8 @@ class CacheItemSelector extends AbstractRequestBuilder
 
                 return $this->hasher->getHashFor($request);
             })
-            ->each(fn ($hash) => $this->taggedCache($this->tags)->forget($hash));
+            ->each(function (string $hash) {
+                $this->taggedCache($this->tags)->forget($hash);
+            });
     }
 }

--- a/tests/CacheItemSelectorIntegrationTest.php
+++ b/tests/CacheItemSelectorIntegrationTest.php
@@ -125,3 +125,18 @@ it('can forget a specific cached request using cache cleaner suffix', function (
     assertRegularResponse($secondResponse);
     assertDifferentResponse($firstResponse, $secondResponse);
 });
+
+it('forgets a cached url even when an earlier url in the list was never cached', function () {
+    $firstResponse = $this->get('/random/2?foo=bar');
+    assertRegularResponse($firstResponse);
+
+    assertCachedResponse($this->get('/random/2?foo=bar'));
+
+    ResponseCache::selectCachedItems()->withParameters(['foo' => 'bar'])
+        ->forUrls(['/random/1', '/random/2'])->forget();
+
+    $responseAfterForget = $this->get('/random/2?foo=bar');
+
+    assertRegularResponse($responseAfterForget);
+    assertDifferentResponse($firstResponse, $responseAfterForget);
+});


### PR DESCRIPTION
## The problem

`ResponseCache::forget([...])`, and more generally `selectCachedItems()->forUrls([...])->forget()`, silently stops forgetting as soon as it encounters a URL that isn't in the cache. Every URL after the first uncached one is skipped.

## Why it happens

`CacheItemSelector::forget()` iterates the hashes like this:

```php
->each(fn ($hash) => $this->taggedCache($this->tags)->forget($hash));
```

`Repository::forget()` returns `false` when the key isn't present, and `Collection::each()` breaks as soon as a callback returns `false`. So the first cache miss halts the whole loop.

This shows up in real code that forgets a set of related URLs where some of them aren't cached. For example, forgetting both the current and the previous slug of a model after its slug changed: the new slug's URL isn't cached yet, so its `forget()` returns `false`, and the old (cached) URL that comes after it is never forgotten. Stale responses keep being served.

## The fix

Use a statement body for the closure so it no longer returns `forget()`'s boolean, letting `each()` run for every URL.

I added a regression test that caches one URL, then forgets a list where an earlier URL was never cached, and asserts the cached URL is gone (it fails on the previous code and passes now). The full suite stays green.
