### PR TITLE
Fix flexible cache expiring after grace instead of lifetime + grace

### DIFF
--- a/src/Middlewares/FlexibleCacheResponse.php
+++ b/src/Middlewares/FlexibleCacheResponse.php
@@ -42,7 +42,7 @@ class FlexibleCacheResponse extends BaseCacheMiddleware
             return $next($request);
         }
 
-        return $this->handleFlexibleCache($request, $next, [$config->lifetime, $config->grace], $config->tags);
+        return $this->handleFlexibleCache($request, $next, [$config->lifetime, $config->lifetime + $config->grace], $config->tags);
     }
 
     public static function for(

--- a/tests/FlexibleResponseCacheTest.php
+++ b/tests/FlexibleResponseCacheTest.php
@@ -111,6 +111,33 @@ it('returns stale content on first request in stale window', function () {
     expect($thirdResponse->getContent())->not->toBe($firstContent);
 });
 
+it('serves stale response for the full grace period after lifetime expires', function () {
+    $firstResponse = $this->get('/flexible/basic');
+    $firstContent = $firstResponse->getContent();
+
+    // lifetime is 5 seconds and grace is 10 seconds: at 12 seconds we are past
+    // the lifetime but still within the grace period, so the stale response
+    // should be served instantly
+    Carbon::setTestNow(Carbon::now()->addSeconds(12));
+
+    $secondResponse = $this->get('/flexible/basic');
+
+    expect($secondResponse->getContent())->toBe($firstContent);
+});
+
+it('serves fresh response for the full lifetime when grace is shorter than lifetime', function () {
+    $firstResponse = $this->get('/flexible/long-lifetime');
+    $firstContent = $firstResponse->getContent();
+
+    // lifetime is 100 seconds: at 50 seconds the cached response is still
+    // fresh, regardless of the shorter 10 second grace period
+    Carbon::setTestNow(Carbon::now()->addSeconds(50));
+
+    $secondResponse = $this->get('/flexible/long-lifetime');
+
+    expect($secondResponse->getContent())->toBe($firstContent);
+});
+
 it('recomputes response when beyond stale window', function () {
     $firstResponse = $this->get('/flexible/basic');
     $firstContent = $firstResponse->getContent();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -172,6 +172,10 @@ abstract class TestCase extends Orchestra
             Route::any('/custom-time', function () {
                 return 'custom-'.Str::random(10);
             })->middleware(FlexibleCacheResponse::for(lifetime: 3, grace: 15));
+
+            Route::any('/long-lifetime', function () {
+                return 'long-'.Str::random(10);
+            })->middleware(FlexibleCacheResponse::for(lifetime: 100, grace: 10));
         });
     }
 


### PR DESCRIPTION
## The bug

The README documents `grace` as an *additional* window after `lifetime`:

> After the lifetime expires, the stale response is still served instantly while the cache refreshes in the background. Once the grace period is over, the cache is considered expired.

But `FlexibleCacheResponse::handle()` passes `[$config->lifetime, $config->grace]` straight into Laravel's `Cache::flexible()`, whose array contract is `[fresh_seconds, total_ttl]` — the **second element is the total TTL** of the entry.

As a result, every flexible-cached response is stored with a TTL of `grace` seconds instead of `lifetime + grace`:

- With the README's own example (`lifetime: hours(1), grace: minutes(5)`), entries expire after **5 minutes**, and since `total TTL < lifetime`, the entry always dies while still "fresh" — the stale-while-revalidate behavior never engages at all. The middleware silently degrades to a plain short-lived cache.
- Even when `grace > lifetime` (as in this repo's test fixtures, e.g. `for(lifetime: 5, grace: 10)`), the stale window is `grace - lifetime` (5s) instead of the documented `grace` (10s).

Reproduction against Redis:

```php
Cache::flexible('demo', [600, 120], fn () => 'hello');
// redis TTL of both the value and the created-timestamp key: 120s
```

The existing tests didn't catch this because every time probe happens to land where both interpretations agree (7s is stale under both readings of `5/10`; 16s is expired under both).

## The fix

Translate the documented semantics to Laravel's contract at the single call site:

```php
[$config->lifetime, $config->lifetime + $config->grace]
```

## Tests

Two new tests that fail on `main` and pin the documented behavior:

- `serves stale response for the full grace period after lifetime expires` — probes t=12s on `for(5, 10)`, i.e. inside the documented grace window but past the misread TTL.
- `serves fresh response for the full lifetime when grace is shorter than lifetime` — a `for(lifetime: 100, grace: 10)` route probed at t=50s, the README-example shape.

Full suite: 78 passed / 4 skipped (pre-existing skips).

## Related: the skipped event tests

The suite contains four event-dispatch tests skipped as "does not work due to a bug in Laravel 11" — two of them asserting `ResponseCacheHitEvent`/`CacheMissedEvent` on the flexible middleware. As written they would **not** have caught this bug (they probe the first request and an immediate second request, where broken and correct code behave identically), but they're the natural building block for a sharper regression test: asserting a genuine `ResponseCacheHitEvent` *inside* the grace window distinguishes a real cache hit from a coincidentally-equal recomputation. The skip reason is obsolete now that v8 requires Laravel 12 — #526 removes the skips (all four pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
