### PR TITLE
Remove obsolete Laravel 11 skips from event dispatch tests

### DIFF
--- a/tests/FlexibleResponseCacheTest.php
+++ b/tests/FlexibleResponseCacheTest.php
@@ -197,7 +197,7 @@ it('fires ResponseCacheHit event when serving from cache', function () {
     $this->get('/flexible/basic');
 
     Event::assertDispatched(ResponseCacheHitEvent::class);
-})->skip('Currently this test does not work due to a bug in Laravel 11');
+});
 
 it('fires CacheMissed event on first request', function () {
     Event::fake();
@@ -205,7 +205,7 @@ it('fires CacheMissed event on first request', function () {
     $this->get('/flexible/basic');
 
     Event::assertDispatched(CacheMissedEvent::class);
-})->skip('Currently this test does not work due to a bug in Laravel 11');
+});
 
 it('parses flexible time format correctly', function () {
     $firstResponse = $this->get('/flexible/basic');

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -25,7 +25,7 @@ it('will fire an event when responding without cache', function () {
     $this->get('/random');
 
     Event::assertDispatched(CacheMissedEvent::class);
-})->skip('Currently this test does not working due to a bug in Laravel 11');
+});
 
 it('will fire an event when responding from cache', function () {
     Event::fake();
@@ -34,7 +34,7 @@ it('will fire an event when responding from cache', function () {
     $this->get('/random');
 
     Event::assertDispatched(ResponseCacheHitEvent::class);
-})->skip('Currently this test does not working due to a bug in Laravel 11');
+});
 
 it('will cache redirects', function () {
     $firstResponse = $this->get('/redirect');


### PR DESCRIPTION
Four event-dispatch tests (two in `IntegrationTest`, two in `FlexibleResponseCacheTest`) are skipped with:

> Currently this test does not work(ing) due to a bug in Laravel 11

Since v8 requires Laravel 12, that reason no longer applies — and indeed all four pass when unskipped. Full suite with the skips removed: **80 passed (642 assertions), 0 skipped, 0 failed**.

No production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
