### PR TITLE
Read cache attributes from invokable controllers registered without a method

### DIFF
--- a/docs/basic-usage/caching-responses.md
+++ b/docs/basic-usage/caching-responses.md
@@ -69,3 +69,20 @@ class PostController
     public function show(Post $post) { /* ... */ }
 }
 ```
+
+Invokable controllers are supported too, whether or not you register the route with an explicit method.
+
+```php
+use Spatie\ResponseCache\Attributes\Cache;
+
+class ShowPostsController
+{
+    #[Cache(lifetime: 5 * 60, tags: ['posts'])]
+    public function __invoke()
+    {
+        return view('posts.index', ['posts' => Post::all()]);
+    }
+}
+
+Route::get('posts', ShowPostsController::class);
+```

--- a/src/Support/AttributeReader.php
+++ b/src/Support/AttributeReader.php
@@ -9,7 +9,7 @@ class AttributeReader
     /**
      * Get the first matching attribute from a controller action.
      *
-     * @param  string  $action  The controller action in "Controller@method" format
+     * @param  string  $action  The controller action in "Controller@method" format, or an invokable controller class name
      * @param  array  $attributeClasses  Array of attribute class names to search for
      * @return object|null The first matching attribute instance or null if none found
      */
@@ -48,8 +48,9 @@ class AttributeReader
 
     protected static function parseAction(string $action): array
     {
+        // An invokable controller can be registered without a method: Route::get('/', MyController::class)
         if (! str_contains($action, '@')) {
-            return [null, null];
+            return [$action, '__invoke'];
         }
 
         return explode('@', $action);

--- a/tests/AttributeTest.php
+++ b/tests/AttributeTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Spatie\ResponseCache\Middlewares\CacheResponse;
+use Spatie\ResponseCache\Test\TestClasses\ClassLevelCacheInvokableController;
+use Spatie\ResponseCache\Test\TestClasses\InvokableCacheController;
+use Spatie\ResponseCache\Test\TestClasses\InvokableNoCacheController;
+
+beforeEach(function () {
+    // Disable the default lifetime, so only a lifetime coming from an attribute can cache a response.
+    config()->set('responsecache.cache.lifetime_in_seconds', 0);
+});
+
+it('reads a method level attribute from an invokable controller registered without a method', function () {
+    Route::any('/invokable', InvokableCacheController::class)->middleware(CacheResponse::class);
+
+    assertRegularResponse($this->get('/invokable'));
+    assertCachedResponse($this->get('/invokable'));
+});
+
+it('reads a class level attribute from an invokable controller registered without a method', function () {
+    Route::any('/invokable-class-level', ClassLevelCacheInvokableController::class)->middleware(CacheResponse::class);
+
+    assertRegularResponse($this->get('/invokable-class-level'));
+    assertCachedResponse($this->get('/invokable-class-level'));
+});
+
+it('reads a no cache attribute from an invokable controller registered without a method', function () {
+    config()->set('responsecache.cache.lifetime_in_seconds', 300);
+
+    Route::any('/invokable-no-cache', InvokableNoCacheController::class)->middleware(CacheResponse::class);
+
+    assertRegularResponse($this->get('/invokable-no-cache'));
+    assertRegularResponse($this->get('/invokable-no-cache'));
+});
+
+it('still reads attributes from an invokable controller registered with an explicit method', function () {
+    Route::any('/invokable-explicit', [InvokableCacheController::class, '__invoke'])->middleware(CacheResponse::class);
+
+    assertRegularResponse($this->get('/invokable-explicit'));
+    assertCachedResponse($this->get('/invokable-explicit'));
+});

--- a/tests/TestClasses/ClassLevelCacheInvokableController.php
+++ b/tests/TestClasses/ClassLevelCacheInvokableController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\ResponseCache\Test\TestClasses;
+
+use Illuminate\Support\Str;
+use Spatie\ResponseCache\Attributes\Cache;
+
+#[Cache(lifetime: 300)]
+class ClassLevelCacheInvokableController
+{
+    public function __invoke(): string
+    {
+        return Str::random();
+    }
+}

--- a/tests/TestClasses/InvokableCacheController.php
+++ b/tests/TestClasses/InvokableCacheController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\ResponseCache\Test\TestClasses;
+
+use Illuminate\Support\Str;
+use Spatie\ResponseCache\Attributes\Cache;
+
+class InvokableCacheController
+{
+    #[Cache(lifetime: 300)]
+    public function __invoke(): string
+    {
+        return Str::random();
+    }
+}

--- a/tests/TestClasses/InvokableNoCacheController.php
+++ b/tests/TestClasses/InvokableNoCacheController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\ResponseCache\Test\TestClasses;
+
+use Illuminate\Support\Str;
+use Spatie\ResponseCache\Attributes\NoCache;
+
+class InvokableNoCacheController
+{
+    #[NoCache]
+    public function __invoke(): string
+    {
+        return Str::random();
+    }
+}


### PR DESCRIPTION
Fixes #524

`AttributeReader::parseAction()` bailed out when the route action had no `@`, which is exactly the case for `Route::get('/posts', ShowPostsController::class)`. Both method-level and class-level `#[Cache]`, `#[FlexibleCache]` and `#[NoCache]` attributes were silently ignored there. It now falls back to `__invoke`.